### PR TITLE
docs: add plugin-agones integration pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -22,6 +22,15 @@
         "pages": [
           "plugins/index",
           {
+            "group": "Agones Integration",
+            "pages": [
+              "plugins/agones/index",
+              "plugins/agones/velocity",
+              "plugins/agones/paper",
+              "plugins/agones/minestom"
+            ]
+          },
+          {
             "group": "Config System",
             "pages": [
               "plugins/config-system/index",

--- a/plugins/agones/index.mdx
+++ b/plugins/agones/index.mdx
@@ -1,0 +1,101 @@
+---
+title: "Agones Integration"
+description: "Overview of plugin-agones across Paper, Velocity, and Minestom gameservers"
+---
+
+Use plugin-agones when your gameserver runs inside the Grounds Kubernetes cluster and you need
+Agones lifecycle state to track your actual player activity without writing custom SDK code.
+
+The plugin translates player events into Agones `Ready` and `Allocated` transitions, and lets the
+Velocity proxy discover running gameservers through the Kubernetes API so players are routed to a
+lobby automatically.
+
+## What the Plugin Does
+
+On Paper and Minestom, the plugin reports your gameserver's Agones state from the current player
+count:
+
+- the first player joins → the runtime calls `Allocate`
+- the last player leaves → the runtime calls `Ready`
+- a 10 second fallback loop reconciles the state if an event is missed
+
+On Velocity, the plugin adds two responsibilities on top of proxy-side state sync:
+
+- it polls the Kubernetes API for running gameservers and registers them with the proxy
+- it routes newly joining players to a lobby server and rejects logins when no lobby is available
+
+<Info>
+`plugin-agones` assumes your gameserver pod runs with an Agones sidecar exposing the SDK on
+`http://localhost:9358`. The Grounds container images ship this configuration by default.
+</Info>
+
+## Module Layout
+
+The repository ships four modules. Gamemode developers consume the platform module matching their
+runtime.
+
+| Module     | Target             | Delivery                               |
+|------------|--------------------|----------------------------------------|
+| `common`   | shared runtime     | used transitively by the three others  |
+| `velocity` | Velocity proxy     | Velocity plugin JAR                    |
+| `paper`    | Paper gameservers  | Paper plugin JAR                       |
+| `minestom` | Minestom servers   | Kotlin library you embed into your app |
+
+## Gameserver Discovery Contract
+
+The Velocity discovery path depends on three conventions that your gameserver deployment must
+follow:
+
+- the pod runs in the `games` Kubernetes namespace
+- the Agones `GameServer` carries the label `grounds/server-type` with one of `lobby`, `game`, or
+  `match`
+- the pod exposes Minecraft on port `25565` and reports its `PodIP` under `status.addresses`
+
+When these conditions are met, the Velocity proxy picks up the gameserver automatically as soon as
+Agones transitions it into `Ready`, `Allocated`, or `Reserved`.
+
+```mermaid
+flowchart LR
+    A[GameServer CRD] -- labeled `grounds/server-type` --> B[Agones state Ready/Allocated/Reserved]
+    B --> C[Velocity DiscoveryService poll]
+    C --> D[Registered with Velocity proxy]
+    D --> E[Players routed to lobby on login]
+    F[Player joins Paper or Minestom] --> G[AgonesHelper.allocate]
+    H[Last player leaves] --> I[AgonesHelper.ready]
+```
+
+<Note>
+`lobby` is treated specially: at least one `Ready`/`Allocated`/`Reserved` gameserver with
+`grounds/server-type=lobby` must exist for new proxy logins to succeed.
+</Note>
+
+## Choose Your Platform
+
+<CardGroup cols={3}>
+<Card title="Velocity" icon="network-wired" href="/plugins/agones/velocity">
+  Learn how the Velocity proxy discovers gameservers, routes players to lobbies, and exposes the
+  `/agones` operator command.
+</Card>
+
+<Card title="Paper" icon="server" href="/plugins/agones/paper">
+  Install the Paper plugin and let the runtime manage your Agones state from player join and quit
+  events.
+</Card>
+
+<Card title="Minestom" icon="cubes" href="/plugins/agones/minestom">
+  Embed the Minestom library in your gamemode server to sync Agones state without touching the SDK
+  directly.
+</Card>
+</CardGroup>
+
+## Typical Use
+
+Use this plugin when:
+
+- your gameserver deploys into the Grounds Agones-managed cluster
+- you want Agones state to reflect real player activity instead of a static allocation call
+- your gamemode publishes its role through `grounds/server-type` so the Velocity proxy can route to
+  it
+
+If you are integrating a new gamemode server now, continue with the platform page that matches your
+runtime.

--- a/plugins/agones/minestom.mdx
+++ b/plugins/agones/minestom.mdx
@@ -1,0 +1,165 @@
+---
+title: "Minestom"
+description: "Embed plugin-agones-minestom as a library in your Minestom gameserver to sync Agones state"
+---
+
+Use the Minestom module of `plugin-agones` when your gamemode runs on Minestom. Unlike the Paper
+build, Minestom has no plugin loader, so this module ships as a library that you embed and start
+explicitly from your server entrypoint.
+
+Once started, the library syncs Agones state from Minestom's player events the same way the Paper
+build does: the first player switches the gameserver to `Allocated`, the last one returning to
+`Ready`.
+
+## Requirements
+
+Your Minestom pod must run with an Agones sidecar exposing the SDK on `http://localhost:9358`. The
+Grounds container images configure this by default.
+
+<Info>
+The module targets Minestom `2026.03.03-1.21.11` and newer. It uses an internal coroutine scope for
+the sidecar calls, so you do not need to provide an executor.
+</Info>
+
+## Add the Dependency
+
+The module is published to the `groundsgg` GitHub Packages Maven registry as
+`gg.grounds:plugin-agones-minestom`.
+
+<Tabs>
+<Tab title="Gradle Kotlin DSL">
+
+```kotlin build.gradle.kts
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/groundsgg/plugin-agones")
+        credentials {
+            username = providers.gradleProperty("github.user").get()
+            password = providers.gradleProperty("github.token").get()
+        }
+    }
+}
+
+dependencies {
+    implementation("gg.grounds:plugin-agones-minestom:<version>")
+}
+```
+
+</Tab>
+
+<Tab title="Gradle Groovy DSL">
+
+```groovy build.gradle
+repositories {
+    maven {
+        url "https://maven.pkg.github.com/groundsgg/plugin-agones"
+        credentials {
+            username = providers.gradleProperty('github.user').get()
+            password = providers.gradleProperty('github.token').get()
+        }
+    }
+}
+
+dependencies {
+    implementation "gg.grounds:plugin-agones-minestom:<version>"
+}
+```
+
+</Tab>
+</Tabs>
+
+<Warning>
+GitHub Packages requires authentication even for public artifacts. Configure `github.user` and
+`github.token` in your `~/.gradle/gradle.properties` or through environment variables.
+</Warning>
+
+## Start and Stop From Your Entrypoint
+
+`GroundsPluginAgones` is the single public entry point. Instantiate it once, call `enable()` during
+startup, and `disable()` during shutdown.
+
+```kotlin
+import gg.grounds.GroundsPluginAgones
+import net.minestom.server.MinecraftServer
+
+fun main() {
+    val server = MinecraftServer.init()
+
+    val agones = GroundsPluginAgones()
+    agones.enable()
+
+    Runtime.getRuntime().addShutdownHook(Thread { agones.disable() })
+
+    server.start("0.0.0.0", 25565)
+}
+```
+
+<Steps>
+<Step title="Call enable during startup">
+`enable()` reads the current player count, sets the initial Agones state, registers a child
+`EventNode` called `grounds-plugin-agones` on the global event handler, and schedules a 10 second
+fallback reconciliation loop.
+
+Calling `enable()` again while the plugin is already running is safe: the existing state is
+disabled first and replaced with a fresh runtime.
+</Step>
+
+<Step title="Call disable during shutdown">
+`disable()` cancels the fallback task, removes the event node from the global handler, and cancels
+the coroutine scope used for sidecar calls. After `disable()`, the instance is reusable with
+another `enable()` call.
+</Step>
+</Steps>
+
+## State Sync Semantics
+
+| Event                                                   | Resulting Agones state |
+|---------------------------------------------------------|------------------------|
+| `PlayerSpawnEvent` when the server had no other players | `Allocated`            |
+| `PlayerSpawnEvent` with existing players                | No change              |
+| `PlayerDisconnectEvent` that leaves the server empty    | `Ready`                |
+| Fallback tick every 10 seconds                          | Reconciled from current player count |
+
+The disconnect path schedules its check on the next Minestom tick so that the connection manager's
+player list is already updated when the check runs.
+
+<Note>
+All state transitions go through `AgonesHelper`, which first fetches the gameserver state from the
+sidecar and only sends `Allocate` or `Ready` when it differs. Repeat calls are no-ops.
+</Note>
+
+## Label Your GameServer
+
+The library only handles state sync. For the Velocity proxy to discover your Minestom gameserver,
+you still need to follow the [discovery contract](/plugins/agones#gameserver-discovery-contract):
+
+- deploy into the `games` namespace
+- add `grounds/server-type: <lobby|game|match>` to the `GameServer` resource metadata
+- listen on port `25565` in the pod
+
+## Failure Modes
+
+<AccordionGroup>
+<Accordion title="Agones sidecar unreachable">
+Errors from the sidecar are logged at error level through the class logger. The fallback loop
+keeps retrying every 10 seconds, so a short sidecar outage is recovered automatically without any
+action from your gamemode.
+</Accordion>
+
+<Accordion title="enable called twice without a disable in between">
+The second call disables the previous runtime first, so the event node and coroutine scope are
+cleaned up before the new one is created. No duplicate listeners are registered.
+</Accordion>
+
+<Accordion title="No Agones sidecar at all">
+If your deployment has no Agones sidecar, every sidecar call fails. The plugin continues to run,
+but cannot influence Agones state. In that setup, consider not loading the module at all to keep
+logs clean.
+</Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+- Read the [Velocity page](/plugins/agones/velocity) to see how the proxy picks up this
+  gameserver once it reaches a running Agones state.
+- Review the [Agones Integration overview](/plugins/agones) for the cross-platform picture.

--- a/plugins/agones/paper.mdx
+++ b/plugins/agones/paper.mdx
@@ -1,0 +1,130 @@
+---
+title: "Paper"
+description: "Install plugin-agones on a Paper gameserver to report Agones state from player events"
+---
+
+Use the Paper module of `plugin-agones` when your gamemode runs on Paper inside the Grounds
+Agones-managed cluster. The plugin turns player join and quit events into Agones state transitions
+so the platform learns when your gameserver is actually occupied.
+
+## Requirements
+
+The Paper gameserver must run with an Agones sidecar exposing the SDK on
+`http://localhost:9358`. The Grounds Paper container image ships this configuration, so no plugin
+configuration is needed if you use the standard image.
+
+<Info>
+The plugin does not read any configuration files. Installing the JAR and running with a working
+Agones sidecar is enough.
+</Info>
+
+## What the Plugin Does
+
+Once loaded, the plugin:
+
+- sets the initial Agones state based on `Bukkit.getOnlinePlayers()` at enable time
+- registers a listener for `PlayerJoinEvent`, `PlayerQuitEvent`, and `PlayerKickEvent`
+- runs a Bukkit scheduler task every 10 seconds that reconciles the state from the current player
+  count
+
+The sync semantics are:
+
+| Situation                                    | Resulting Agones state |
+|----------------------------------------------|------------------------|
+| First player joins an empty server           | `Allocated`            |
+| A player joins a server that already has one | State is unchanged     |
+| The last player leaves or is kicked          | `Ready`                |
+| The gameserver starts with no players        | `Ready`                |
+| The gameserver starts with players already on it | `Allocated`        |
+
+The quit and kick path waits one server tick before evaluating, so the online player list is
+accurate even when the event fires before the player is removed.
+
+<Note>
+State transitions are idempotent. The plugin checks the current state through the sidecar before
+it calls `Allocate` or `Ready`, so repeat events do not cause repeat calls.
+</Note>
+
+## Install
+
+<Steps>
+<Step title="Add the plugin JAR">
+
+Drop the Paper module artifact into the `plugins/` directory of your Paper gameserver, next to
+your gamemode plugins.
+
+```text
+plugins/
+├── plugin-agones-paper.jar
+└── your-gamemode.jar
+```
+
+</Step>
+
+<Step title="Deploy with an Agones sidecar">
+
+Make sure your pod template includes the Agones sidecar. The Grounds Paper container images
+include the sidecar configuration out of the box, so this is a no-op if you use them.
+
+<Check>
+On startup, the plugin logs `Started Agones plugin successfully (platform=paper)` when
+initialization succeeds.
+</Check>
+
+</Step>
+
+<Step title="Label your GameServer">
+
+For the Velocity proxy to discover this gameserver, set the `grounds/server-type` label on the
+`GameServer` resource.
+
+```yaml
+apiVersion: agones.dev/v1
+kind: GameServer
+metadata:
+  namespace: games
+  labels:
+    grounds/server-type: game
+```
+
+See the [shared discovery contract](/plugins/agones#gameserver-discovery-contract) for the full
+set of labels and network expectations.
+
+</Step>
+</Steps>
+
+## Integration With Your Gamemode
+
+No code changes are needed in your gamemode plugin. The Agones state is managed entirely by the
+event listener inside `plugin-agones-paper`.
+
+Do not call Agones `Allocate` or `Ready` from your own code. Redundant calls are safe because the
+plugin short-circuits on the current state, but they add noise and make state transitions harder
+to reason about.
+
+<Tip>
+If your gamemode needs to prevent the gameserver from returning to `Ready` while a round is still
+in progress, plan that through Agones allocation handling or player counters instead of bypassing
+the plugin.
+</Tip>
+
+## Failure Modes
+
+<AccordionGroup>
+<Accordion title="Agones sidecar unreachable on startup">
+The plugin starts normally and continues to retry on every player event and on the 10 second
+fallback loop. Errors are logged at severe level with the underlying throwable attached. The
+gameserver keeps whatever state Agones last persisted until the sidecar recovers.
+</Accordion>
+
+<Accordion title="Events fire out of order during server shutdown">
+The 10 second fallback loop backstops missed or re-ordered events. As long as the Paper scheduler
+runs once after the player list settles, the state is reconciled.
+</Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+- Review the [Velocity page](/plugins/agones/velocity) to understand how the proxy discovers this
+  gameserver once its Agones state transitions.
+- Read the [Agones Integration overview](/plugins/agones) for the end-to-end lifecycle picture.

--- a/plugins/agones/velocity.mdx
+++ b/plugins/agones/velocity.mdx
@@ -134,9 +134,9 @@ issue redundant calls to the sidecar.
 <AccordionGroup>
 <Accordion title="Kubernetes client fails to initialize">
 If the plugin cannot build a Kubernetes client at startup, discovery stays disabled for the
-process lifetime. The plugin logs the reason and continues without registering servers. The proxy
-accepts no logins until a lobby is discoverable again — which only happens after a restart with
-a working Kubernetes configuration.
+process lifetime. The plugin logs the reason and continues without unregistering configured
+servers, registering lobby-routing listeners, or polling Kubernetes. Existing `velocity.toml`
+servers remain registered until the proxy restarts with a working Kubernetes configuration.
 </Accordion>
 
 <Accordion title="Agones sidecar unreachable">

--- a/plugins/agones/velocity.mdx
+++ b/plugins/agones/velocity.mdx
@@ -1,0 +1,162 @@
+---
+title: "Velocity"
+description: "Proxy-side Agones gameserver discovery, lobby routing, and operator command"
+---
+
+Use the Velocity module of `plugin-agones` when you run the Grounds proxy in front of
+Agones-managed gameservers. The plugin replaces the static `velocity.toml` server list with live
+Kubernetes-driven discovery and routes joining players to a lobby.
+
+## Requirements
+
+The plugin assumes the following environment:
+
+- the Velocity pod runs in the `games` namespace alongside its gameservers
+- the pod has read access to the Agones `gameservers.agones.dev` custom resources (`list` verb)
+- an Agones sidecar runs next to the Velocity container and exposes the SDK on
+  `http://localhost:9358`
+
+<Warning>
+The plugin unregisters every server defined in `velocity.toml` during startup. Your `velocity.toml`
+`[servers]` section is effectively ignored once the plugin is loaded.
+</Warning>
+
+## What the Plugin Provides
+
+Once the plugin starts, it runs two responsibilities in parallel on the proxy:
+
+- `GameServerStateManager` syncs the proxy's own Agones state (`Ready` or `Allocated`) with the
+  connected player count
+- `DiscoveryService` polls Kubernetes every two seconds and keeps Velocity's server registry in
+  sync with the running gameservers
+
+Every discovered gameserver is registered under its Kubernetes resource name. The server's role is
+read from the `grounds/server-type` label and cached for routing and the `/agones` command.
+
+## Gameserver Requirements
+
+For a gameserver pod to appear in Velocity, it must satisfy the discovery contract:
+
+<Steps>
+<Step title="Deploy into the games namespace">
+The discovery query is scoped to the `games` namespace. Gameservers outside that namespace are
+ignored.
+</Step>
+
+<Step title="Label the GameServer with a role">
+Set `grounds/server-type` to `lobby`, `game`, or `match` on the `GameServer` resource metadata.
+Unlabeled gameservers are skipped.
+
+```yaml
+apiVersion: agones.dev/v1
+kind: GameServer
+metadata:
+  name: my-lobby
+  namespace: games
+  labels:
+    grounds/server-type: lobby
+```
+</Step>
+
+<Step title="Expose Minecraft on port 25565">
+The proxy registers the pod at `PodIP:25565`. The plugin does not honor Agones allocated ports —
+the gameserver must listen on the default Minecraft port inside the pod.
+</Step>
+
+<Step title="Reach a running Agones state">
+Only gameservers in `Ready`, `Allocated`, or `Reserved` state are registered. Transitions out of
+these states unregister the server on the next poll.
+</Step>
+</Steps>
+
+<Check>
+If your gameserver follows all four steps, it appears in `/agones` on the proxy within two seconds
+of reaching a running state.
+</Check>
+
+## Lobby Routing
+
+The plugin treats `grounds/server-type=lobby` as the entry point for new connections.
+
+| Event                                            | Behavior                                                |
+|--------------------------------------------------|---------------------------------------------------------|
+| Player logs in and at least one lobby is running | Login succeeds and the proxy routes the player to a lobby |
+| Player logs in and no lobby is running           | Login is denied with a user-facing message              |
+| `PlayerChooseInitialServerEvent` with no server  | The plugin sets the first registered lobby as target    |
+
+If another plugin already sets an initial server (for example through a rejoin feature), the
+discovery plugin does not override that choice.
+
+<Note>
+"First registered lobby" is a deterministic but unordered pick from Velocity's internal map. If you
+need priority routing, plan to pair this with party-aware routing later.
+</Note>
+
+## The `/agones` Command
+
+The plugin registers an operator command for inspecting the current proxy state.
+
+```text
+/agones
+```
+
+| Attribute    | Value                       |
+|--------------|-----------------------------|
+| Permission   | `grounds.command.agones`    |
+| Console      | always allowed              |
+| Output scope | all registered proxy servers |
+
+The command prints every registered server with its role, address, and connected player count.
+Roles are color-coded: `lobby` (green), `game` (aqua), `match` (light purple), `unknown` (gray).
+
+Example output:
+
+```text
+--- Agones Servers ---
+ lobby-1 [lobby] 10.42.3.14:25565 (12 players)
+ game-survival-7 [game] 10.42.4.22:25565 (0 players)
+Total: 2 servers, 12 players
+```
+
+## State Sync on the Proxy
+
+The proxy itself runs as an Agones gameserver, so the plugin also manages its own state:
+
+- the plugin calls `Allocate` when the first player logs in
+- the plugin calls `Ready` when the last player disconnects
+- a 10 second fallback loop reconciles the state in case events are missed
+
+The state sync is idempotent: if the proxy is already in the desired state, the plugin does not
+issue redundant calls to the sidecar.
+
+## Failure Modes
+
+<AccordionGroup>
+<Accordion title="Kubernetes client fails to initialize">
+If the plugin cannot build a Kubernetes client at startup, discovery stays disabled for the
+process lifetime. The plugin logs the reason and continues without registering servers. The proxy
+accepts no logins until a lobby is discoverable again — which only happens after a restart with
+a working Kubernetes configuration.
+</Accordion>
+
+<Accordion title="Agones sidecar unreachable">
+The proxy-side state sync logs the failure and keeps trying on its fallback loop. Discovery and
+routing continue to work because they depend on the Kubernetes API, not on the sidecar.
+</Accordion>
+
+<Accordion title="Gameserver missing a PodIP">
+Gameservers without a `PodIP` entry in `status.addresses` are skipped and logged as
+`missing_pod_ip`. This usually clears up on the next poll once Agones populates the status.
+</Accordion>
+
+<Accordion title="Gameserver missing the server-type label">
+Unlabeled gameservers are silently skipped. Check the `GameServer` resource if you expect it to
+appear and it does not.
+</Accordion>
+</AccordionGroup>
+
+## Next Steps
+
+- Read [Paper](/plugins/agones/paper) or [Minestom](/plugins/agones/minestom) to set up gameservers
+  that the Velocity proxy will discover.
+- Review [Agones Integration](/plugins/agones) for the shared discovery contract.

--- a/plugins/index.mdx
+++ b/plugins/index.mdx
@@ -8,6 +8,11 @@ Use the plugins section when you need documentation for components that run insi
 ## Available Plugins
 
 <CardGroup cols={2}>
+<Card title="Agones Integration" icon="server" href="/plugins/agones">
+  Sync Agones gameserver state with player activity across Paper, Velocity, and Minestom, and let
+  the proxy discover gameservers from the Kubernetes API.
+</Card>
+
 <Card title="Config System" icon="sliders" href="/plugins/config-system">
   Learn how the Grounds Config System connects the Config Plugin in Paper or Velocity to the
   backend Config API.


### PR DESCRIPTION
## Summary
- Adds four Mintlify pages under `plugins/agones`: an overview plus one page per platform module (`velocity`, `paper`, `minestom`).
- Documents the shared gameserver discovery contract (namespace, `grounds/server-type` label, port 25565, running Agones states) and the `/agones` operator command.
- Wires the pages into `docs.json` as a new **Agones Integration** group under the Plugins tab and surfaces the entry point from `plugins/index.mdx`.

Audience is gamemode developers integrating with the Grounds Agones-managed cluster — not platform ops. Style follows the existing `plugins/config-system` pages (Steps, Tabs, AccordionGroup for failure modes, CardGroup for cross-links).

## Test plan
- [ ] \`mintlify dev\` renders all four new pages without broken internal links
- [ ] \`docs.json\` parses as valid JSON (verified locally)
- [ ] Navigation shows **Agones Integration** as the first group under Plugins, above Config System
- [ ] \`plugins/index.mdx\` shows the new Agones card

🤖 Generated with [Claude Code](https://claude.com/claude-code)