### PR TITLE
docs: add external-dns-bunny-webhook platform pages

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -69,6 +69,14 @@
               "platform/keycloak-minecraft-idp/installation",
               "platform/keycloak-minecraft-idp/configuration"
             ]
+          },
+          {
+            "group": "ExternalDNS Bunny Webhook",
+            "pages": [
+              "platform/external-dns-bunny-webhook/index",
+              "platform/external-dns-bunny-webhook/installation",
+              "platform/external-dns-bunny-webhook/configuration"
+            ]
           }
         ]
       },

--- a/platform/external-dns-bunny-webhook/configuration.mdx
+++ b/platform/external-dns-bunny-webhook/configuration.mdx
@@ -1,0 +1,171 @@
+---
+title: "Configuration"
+description: "Runtime environment variables and Bunny-specific annotations for the webhook provider"
+---
+
+Use this page when you need to tune the webhook's runtime settings or control Bunny-specific
+record behavior from your Kubernetes sources.
+
+## Runtime Environment Variables
+
+The webhook reads all configuration from environment variables at startup.
+
+| Variable                | Required | Default     | Purpose                                                                     |
+|-------------------------|----------|-------------|-----------------------------------------------------------------------------|
+| `BUNNY_API_KEY`         | Yes      | —           | API key used to authenticate with the Bunny.net API                         |
+| `BUNNY_DRY_RUN`         | No       | `false`     | When `true`, the provider logs intended changes but does not call the API  |
+| `WEBHOOK_HOST`          | No       | `localhost` | Host the webhook endpoint binds to                                          |
+| `WEBHOOK_PORT`          | No       | `8888`      | Port the ExternalDNS controller calls                                       |
+| `WEBHOOK_READ_TIMEOUT`  | No       | `60s`       | Read timeout for the webhook HTTP server                                    |
+| `WEBHOOK_WRITE_TIMEOUT` | No       | `60s`       | Write timeout for the webhook HTTP server                                   |
+| `HEALTH_HOST`           | No       | `0.0.0.0`   | Host the health endpoint binds to                                           |
+| `HEALTH_PORT`           | No       | `8080`      | Port for Kubernetes liveness and readiness probes                           |
+| `HEALTH_READ_TIMEOUT`   | No       | `60s`       | Read timeout for the health HTTP server                                     |
+| `HEALTH_WRITE_TIMEOUT`  | No       | `60s`       | Write timeout for the health HTTP server                                    |
+
+<Tip>
+Use `BUNNY_DRY_RUN=true` when you migrate existing records into ExternalDNS management. The logs
+show exactly which records the webhook would create, update, or delete — without changing Bunny.
+</Tip>
+
+## Bunny-Specific Annotations
+
+Add these annotations to the Kubernetes source (Service, Ingress, Gateway route, and similar) to
+control record behavior inside Bunny.net. All annotations are optional and fall back to safe
+defaults when omitted.
+
+### Record Controls
+
+#### Disable a record
+
+Set `external-dns.alpha.kubernetes.io/webhook-bunny-disabled` to `true` to keep the record
+managed by ExternalDNS but disabled in Bunny. Disabled records do not answer DNS queries but stay
+visible in the dashboard.
+
+```yaml
+metadata:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: api.example.com
+    external-dns.alpha.kubernetes.io/webhook-bunny-disabled: "true"
+```
+
+#### Monitor type
+
+Set `external-dns.alpha.kubernetes.io/webhook-bunny-monitor-type` to one of `none`, `http`, or
+`ping` to control Bunny's built-in record monitoring. The default is `none`.
+
+| Value  | Behavior                                               |
+|--------|--------------------------------------------------------|
+| `none` | No monitoring. Standard DNS record                     |
+| `http` | HTTP health check against the record's target          |
+| `ping` | ICMP ping check against the record's target            |
+
+#### Weight
+
+Set `external-dns.alpha.kubernetes.io/webhook-bunny-weight` to an integer between `1` and `100`
+to control record weighting in Bunny. The default is `100`.
+
+<Note>
+Values outside the valid range are clamped to the nearest valid value. Non-integer values are
+rejected and the default is used instead.
+</Note>
+
+### Smart DNS Records
+
+<Tooltip tip="Smart DNS is Bunny's feature for routing DNS answers based on latency or geography.">Smart DNS</Tooltip>
+is supported on `A` and `AAAA` records. To model multiple smart records under the same hostname,
+create one Kubernetes source per record and differentiate them with
+`external-dns.alpha.kubernetes.io/set-identifier`.
+
+The webhook encodes the smart settings into `SetIdentifier` automatically when it reads back
+records from Bunny (`latency:<zone>` or `geo:<lat>,<long>`), so ExternalDNS sees a stable view
+across reconciles.
+
+#### Routing type
+
+Set `external-dns.alpha.kubernetes.io/webhook-bunny-smart-type` to `none`, `latency`, or `geo`.
+Unknown values fall back to `none` and the webhook logs a warning.
+
+#### Latency routing
+
+Required when `smart-type=latency`. Set
+`external-dns.alpha.kubernetes.io/webhook-bunny-smart-latency-zone` to a Bunny zone string —
+typically an ISO country or region code such as `DE`, `US`, or `SG`.
+
+Missing or empty values fall back to non-smart routing with a warning log.
+
+#### Geographic routing
+
+Required when `smart-type=geo`. Set both coordinate annotations:
+
+- `external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-lat` — latitude between `-90` and `90`
+- `external-dns.alpha.kubernetes.io/webhook-bunny-smart-geo-long` — longitude between `-180` and `180`
+
+Out-of-range or unparseable coordinates fall back to non-smart routing with a warning log.
+
+#### Example: latency routing across regions
+
+```yaml
+# Service in the EU cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-eu
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: api.example.com
+    external-dns.alpha.kubernetes.io/set-identifier: eu
+    external-dns.alpha.kubernetes.io/webhook-bunny-smart-type: latency
+    external-dns.alpha.kubernetes.io/webhook-bunny-smart-latency-zone: "DE"
+---
+# Service in the US cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-us
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: api.example.com
+    external-dns.alpha.kubernetes.io/set-identifier: us
+    external-dns.alpha.kubernetes.io/webhook-bunny-smart-type: latency
+    external-dns.alpha.kubernetes.io/webhook-bunny-smart-latency-zone: "US"
+```
+
+## Interaction With Dashboard-Managed Records
+
+<Warning>
+If you manually created a smart record in the Bunny.net dashboard and there is no matching
+Kubernetes source with the smart annotations, ExternalDNS detects drift and tries to strip the
+smart settings on the next reconcile.
+</Warning>
+
+To avoid unwanted changes, pick one of:
+
+- add matching smart annotations to a Kubernetes source so the webhook treats the record as
+  managed
+- exclude the record from ExternalDNS management through the ownership TXT registry so the
+  controller does not consider it its own
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Records do not appear in Bunny.net">
+Check the webhook container logs first:
+
+```shell
+kubectl -n external-dns logs deploy/external-dns -c webhook
+```
+
+Common causes: missing or invalid `BUNNY_API_KEY`, an ExternalDNS `domainFilters` value that does
+not match the hostname, or `policy: sync` required for deletions that is not set on the chart.
+</Accordion>
+
+<Accordion title="Webhook refuses to start">
+Check that the `BUNNY_API_KEY` environment variable is wired from a valid secret and that the
+secret exists in the same namespace as the ExternalDNS release.
+</Accordion>
+
+<Accordion title="Smart record annotation seems to be ignored">
+Unknown `smart-type` values, missing `latency-zone`, and out-of-range coordinates all fall back
+to non-smart routing with a warning log. Look for a warning entry in the webhook logs to confirm
+which annotation was rejected.
+</Accordion>
+</AccordionGroup>

--- a/platform/external-dns-bunny-webhook/configuration.mdx
+++ b/platform/external-dns-bunny-webhook/configuration.mdx
@@ -94,6 +94,199 @@ typically an ISO country or region code such as `DE`, `US`, or `SG`.
 
 Missing or empty values fall back to non-smart routing with a warning log.
 
+##### Available Latency Regions
+
+Bunny.net exposes the authoritative list through the public Region API. Use `RegionCode` values
+for the `webhook-bunny-smart-latency-zone` annotation.
+
+```shell
+curl https://api.bunny.net/region | jq '.[] | select(.AllowLatencyRouting) | .RegionCode'
+```
+
+<Note>
+The tables below are a snapshot from April 2026 of regions with `AllowLatencyRouting: true`. Regions
+without latency routing are intentionally omitted. For changes, query the API above.
+</Note>
+
+<AccordionGroup>
+<Accordion title="Europe">
+
+| Region Code | Name                | Country |
+|-------------|---------------------|---------|
+| `AMS`       | Amsterdam           | NL      |
+| `AT`        | Vienna              | AT      |
+| `AT2`       | Vienna 2            | AT      |
+| `BA`        | Novi Travnik        | BA      |
+| `BE`        | Brussels            | BE      |
+| `BG`        | Sofia               | BG      |
+| `BU`        | Bucharest           | RO      |
+| `CH`        | Zurich              | CH      |
+| `CZ`        | Prague              | CZ      |
+| `DD`        | Dusseldorf          | DE      |
+| `DE`        | Frankfurt           | DE      |
+| `DE2`       | Frankfurt 2         | DE      |
+| `DK`        | Copenhagen          | DK      |
+| `ES`        | Madrid              | ES      |
+| `FI`        | Helsinki            | FI      |
+| `FR`        | Paris               | FR      |
+| `GR`        | Athens              | GR      |
+| `HR`        | Zagreb              | HR      |
+| `HU`        | Budapest            | HU      |
+| `IE`        | Dublin              | IE      |
+| `IS`        | Keflavik            | IS      |
+| `IT`        | Milan               | IT      |
+| `KH`        | Khabarovsk          | RU      |
+| `KY`        | Krasnoyarsk         | RU      |
+| `LJ`        | Ljubljana           | SI      |
+| `LT`        | Vilnius             | LT      |
+| `LU`        | Luxembourg          | LU      |
+| `LV`        | Riga                | LV      |
+| `MD`        | Chisinau            | MD      |
+| `MS`        | Marseille           | FR      |
+| `NO`        | Oslo                | NO      |
+| `PL`        | Warsaw              | PL      |
+| `PT`        | Lisbon              | PT      |
+| `RS`        | Belgrade            | RS      |
+| `RU`        | Moscow              | RU      |
+| `SE`        | Stockholm           | SE      |
+| `SK`        | Bratislava          | SK      |
+| `UA`        | Kyiv                | UA      |
+| `UK`        | London              | GB      |
+
+</Accordion>
+
+<Accordion title="North America">
+
+| Region Code | Name              | Country |
+|-------------|-------------------|---------|
+| `ASB`       | Ashburn, VA       | US      |
+| `BO`        | Boston, MA        | US      |
+| `CA`        | Toronto           | CA      |
+| `CLT`       | Charlotte, NC     | US      |
+| `DEN`       | Denver, CO        | US      |
+| `DEN2`      | Denver 2, CO      | US      |
+| `GA`        | Atlanta, GA       | US      |
+| `GA2`       | Atlanta 2, GA     | US      |
+| `HI`        | Honolulu, HI      | US      |
+| `HOU`       | Houston, TX       | US      |
+| `HOU2`      | Houston 2, TX     | US      |
+| `IL`        | Chicago, IL       | US      |
+| `KC`        | Kansas City, MO   | US      |
+| `LA`        | Los Angeles, CA   | US      |
+| `LA2`       | Los Angeles 2, CA | US      |
+| `MI`        | Miami, FL         | US      |
+| `MI2`       | Miami 2, FL       | US      |
+| `MN`        | Montreal          | CA      |
+| `MSP`       | Minneapolis, MN   | US      |
+| `NY`        | New York City, NY | US      |
+| `OG`        | Ogden, UT         | US      |
+| `PB`        | Pittsburgh, PA    | US      |
+| `PHX`       | Phoenix, AZ       | US      |
+| `SIL`       | San Jose, CA      | US      |
+| `TX`        | Dallas, TX        | US      |
+| `VA`        | Vancouver         | CA      |
+| `WA`        | Seattle, WA       | US      |
+
+</Accordion>
+
+<Accordion title="Asia">
+
+| Region Code | Name           | Country |
+|-------------|----------------|---------|
+| `AM`        | Yerevan        | AM      |
+| `AZ`        | Baku           | AZ      |
+| `BD`        | Dhaka          | BD      |
+| `CEN`       | Chennai        | IN      |
+| `CY`        | Nicosia        | CY      |
+| `GEO`       | Tbilisi        | GE      |
+| `GU`        | Hagatna        | GU      |
+| `HK`        | Hong Kong      | HK      |
+| `ID`        | Jakarta        | ID      |
+| `IN`        | Bangalore      | IN      |
+| `ISR`       | Tel Aviv       | IL      |
+| `JP`        | Tokyo          | JP      |
+| `KG`        | Bishkek        | KG      |
+| `KR`        | Seoul          | KR      |
+| `KZ`        | Almaty         | KZ      |
+| `MG`        | Ulaanbaatar    | MN      |
+| `MU`        | Mumbai         | IN      |
+| `MY`        | Kuala Lumpur   | MY      |
+| `ND`        | New Delhi      | IN      |
+| `NP`        | Kathmandu      | NP      |
+| `PH`        | Manila         | PH      |
+| `PK`        | Karachi        | PK      |
+| `PP`        | Phnom Penh     | KH      |
+| `RGN`       | Yangon         | MM      |
+| `SG`        | Singapore      | SG      |
+| `SG2`       | Singapore 2    | SG      |
+| `TH`        | Bangkok        | TH      |
+| `TR`        | Istanbul       | TR      |
+| `TW`        | Taipei         | TW      |
+| `VN`        | Ho Chi Minh    | VN      |
+
+</Accordion>
+
+<Accordion title="Oceania">
+
+| Region Code | Name       | Country |
+|-------------|------------|---------|
+| `ADL`       | Adelaide   | AU      |
+| `AUC`       | Auckland   | NZ      |
+| `BRB`       | Brisbane   | AU      |
+| `MEL`       | Melbourne  | AU      |
+| `PER`       | Perth      | AU      |
+| `SYD`       | Sydney     | AU      |
+
+</Accordion>
+
+<Accordion title="South America and LATAM">
+
+| Region Code | Name              | Country |
+|-------------|-------------------|---------|
+| `AR`        | Buenos Aires      | AR      |
+| `BOL`       | Sucre             | BO      |
+| `BR`        | Sao Paulo         | BR      |
+| `BS`        | Brasilia          | BR      |
+| `CL`        | Santiago          | CL      |
+| `CO`        | Bogota            | CO      |
+| `CR`        | San Pedro         | CR      |
+| `EC`        | Quito             | EC      |
+| `FO`        | Fortaleza         | BR      |
+| `GT`        | Guatemala         | GT      |
+| `LAP`       | La Paz            | BO      |
+| `MX`        | Mexico City       | MX      |
+| `PA`        | Porto Alegre      | BR      |
+| `PE`        | Lima              | PE      |
+| `PR`        | San Juan          | PR      |
+| `RJ`        | Rio de Janeiro    | BR      |
+
+</Accordion>
+
+<Accordion title="Africa and Middle East">
+
+| Region Code | Name             | Country |
+|-------------|------------------|---------|
+| `AE`        | Dubai            | AE      |
+| `AO`        | Luanda           | AO      |
+| `BHR`       | Bahrain          | BH      |
+| `CT`        | Cape Town        | ZA      |
+| `EG`        | Cairo            | EG      |
+| `EG2`       | Cairo 2          | EG      |
+| `FU`        | Fujairah         | AE      |
+| `IQ`        | Baghdad          | IQ      |
+| `IQ2`       | Baghdad 2        | IQ      |
+| `JH`        | Johannesburg     | ZA      |
+| `JO`        | Amman            | JO      |
+| `KE`        | Nairobi          | KE      |
+| `KWI`       | Kuwait City      | KW      |
+| `NG`        | Lagos            | NG      |
+| `RBA`       | Rabat            | MA      |
+| `RI`        | Riyadh           | SA      |
+| `TN`        | Tunis            | TN      |
+
+</Accordion>
+</AccordionGroup>
+
 #### Geographic routing
 
 Required when `smart-type=geo`. Set both coordinate annotations:

--- a/platform/external-dns-bunny-webhook/index.mdx
+++ b/platform/external-dns-bunny-webhook/index.mdx
@@ -1,0 +1,72 @@
+---
+title: "Overview"
+description: "ExternalDNS webhook provider that manages Bunny.net DNS records from Kubernetes"
+---
+
+Use `external-dns-bunny-webhook` when you want Kubernetes services, ingresses, or gateway routes
+to publish their DNS records directly into <Tooltip tip="DNS authoritative service provided by Bunny.net — the same vendor that runs Bunny CDN.">Bunny.net</Tooltip>
+through <Tooltip tip="Kubernetes addon that turns Service and Ingress hostnames into DNS records on external providers." cta="Read external-dns docs" href="https://kubernetes-sigs.github.io/external-dns/">ExternalDNS</Tooltip>.
+
+The webhook runs as a sidecar next to the official ExternalDNS controller and speaks the
+ExternalDNS webhook provider contract. ExternalDNS reconciles desired records against your cluster
+state, the webhook translates those records into Bunny.net API calls.
+
+## Features
+
+- Manages A, AAAA, CNAME, TXT, and related records through the Bunny.net API
+- Supports the standard ExternalDNS ownership <Tooltip tip="A DNS TXT record that external-dns writes to mark the records it owns. Prevents external-dns from touching records created manually or by another tool.">TXT registry</Tooltip>
+- Exposes health and metrics endpoints on a separate port for Kubernetes probes
+- Adds Bunny-specific record controls through annotations: disabled records, monitoring, weight,
+  and smart DNS routing by latency or geography
+
+## When to Use It
+
+Use this provider when your DNS lives in Bunny.net and you want Kubernetes to own the record
+lifecycle. If you mix manual dashboard records with ExternalDNS-managed records, use the
+ownership TXT registry to keep the two sets separate.
+
+<Note>
+The provider is a standalone ExternalDNS extension. It does not require any other Grounds service
+and can be deployed into any Kubernetes cluster that runs ExternalDNS.
+</Note>
+
+## How It Fits Together
+
+```mermaid
+flowchart LR
+    A[Kubernetes Service or Ingress] -- annotations --> B[ExternalDNS controller]
+    B -- webhook provider API --> C[external-dns-bunny-webhook]
+    C -- HTTPS API --> D[Bunny.net DNS]
+    B -- ownership TXT records --> D
+```
+
+ExternalDNS and the webhook run in the same pod. The controller calls the webhook on
+`http://localhost:8888`, and the webhook exposes a separate health endpoint on
+`http://0.0.0.0:8080` for Kubernetes probes.
+
+## Maintainership
+
+The provider is forked and maintained under the `groundsgg` organization but it is not an
+officially Bunny.net-supported product. Bugs and feature requests should go to the
+[GitHub repository](https://github.com/groundsgg/external-dns-bunny-webhook). Questions about the
+Bunny.net DNS product itself should go to Bunny.net support.
+
+## Quick Links
+
+<CardGroup cols={2}>
+<Card title="Installation" icon="download" href="/platform/external-dns-bunny-webhook/installation">
+  Deploy the webhook alongside ExternalDNS using the official Helm chart.
+</Card>
+
+<Card title="Configuration" icon="sliders" href="/platform/external-dns-bunny-webhook/configuration">
+  Tune runtime environment variables and control records through Bunny-specific annotations.
+</Card>
+
+<Card title="GitHub Repository" icon="github" href="https://github.com/groundsgg/external-dns-bunny-webhook">
+  Browse the source, releases, and issue tracker.
+</Card>
+
+<Card title="ExternalDNS Docs" icon="book" href="https://kubernetes-sigs.github.io/external-dns/">
+  Reference documentation for the ExternalDNS controller that drives this provider.
+</Card>
+</CardGroup>

--- a/platform/external-dns-bunny-webhook/installation.mdx
+++ b/platform/external-dns-bunny-webhook/installation.mdx
@@ -1,0 +1,132 @@
+---
+title: "Installation"
+description: "Deploy external-dns-bunny-webhook alongside ExternalDNS in Kubernetes"
+---
+
+<Info>
+  **Prerequisites**:
+  - A Kubernetes cluster with Helm 3
+  - A Bunny.net account with an API key that can manage DNS zones
+  - The ExternalDNS Helm chart repository added to Helm
+</Info>
+
+Use these steps to deploy the webhook as a sidecar to the official ExternalDNS controller using
+the `kubernetes-sigs/external-dns` Helm chart.
+
+## Add the ExternalDNS Helm Repository
+
+You can skip this step if you already have the repository configured.
+
+```shell
+helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
+helm repo update
+```
+
+## Store the Bunny.net API Key as a Secret
+
+The webhook reads the API key from the `BUNNY_API_KEY` environment variable. The default
+configuration expects a Kubernetes secret named `external-dns-bunny-secret` with a key called
+`api-key`.
+
+```shell
+kubectl create secret generic external-dns-bunny-secret \
+  --namespace external-dns \
+  --from-literal=api-key=<your-bunny-api-key>
+```
+
+<Warning>
+Do not commit the API key to Git. Use a secrets manager, sealed secrets, or your cluster's
+external secret integration in production.
+</Warning>
+
+## Prepare the Helm Values File
+
+Save this values file as `bunny-values.yaml`. The Grounds container image is published to the
+GitHub Container Registry at `ghcr.io/groundsgg/external-dns-bunny-webhook`.
+
+```yaml bunny-values.yaml
+namespace: external-dns
+provider:
+  name: webhook
+  webhook:
+    image:
+      repository: ghcr.io/groundsgg/external-dns-bunny-webhook
+      tag: v0.4.1
+    env:
+      - name: BUNNY_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: external-dns-bunny-secret
+            key: api-key
+```
+
+<Tip>
+Pin the `tag` field to a specific release. Track the
+[latest release](https://github.com/groundsgg/external-dns-bunny-webhook/releases) and bump the
+tag deliberately.
+</Tip>
+
+The ExternalDNS chart wires the webhook container into the same pod as the controller and sets up
+the service accounts, RBAC, and metrics endpoints for you.
+
+## Install the Chart
+
+Install ExternalDNS with the values file. The example pins the chart version for reproducibility.
+
+```shell
+helm upgrade --install external-dns external-dns/external-dns \
+  --namespace external-dns \
+  --create-namespace \
+  --version 1.15.0 \
+  --values bunny-values.yaml
+```
+
+<Check>
+Verify that both containers in the pod report ready before you continue:
+
+```shell
+kubectl -n external-dns get pods
+```
+
+You should see one pod with two ready containers — the ExternalDNS controller and the Bunny
+webhook.
+</Check>
+
+## Verify Record Reconciliation
+
+Create a test service or ingress with an `external-dns.alpha.kubernetes.io/hostname` annotation.
+ExternalDNS picks it up on the next reconcile loop and calls the webhook, which creates the
+Bunny.net DNS record.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+  namespace: default
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: hello.example.com
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+  selector:
+    app: hello
+```
+
+Check the logs of the webhook container to confirm that the record was written:
+
+```shell
+kubectl -n external-dns logs deploy/external-dns -c webhook
+```
+
+<Check>
+The webhook logs an `upserted` entry for `hello.example.com` and the record appears in the
+Bunny.net DNS dashboard.
+</Check>
+
+## Next Steps
+
+- See the [configuration guide](/platform/external-dns-bunny-webhook/configuration) for runtime
+  environment variables and the Bunny-specific annotations that let you enable monitoring,
+  weight, or smart DNS routing per record.

--- a/platform/index.mdx
+++ b/platform/index.mdx
@@ -19,6 +19,10 @@ Use the platform section when you need shared infrastructure components, deploym
 <Card title="Keycloak Minecraft IDP Plugin" icon="shield-halved" href="/platform/keycloak-minecraft-idp">
   General-purpose Keycloak identity provider plugin that enables Minecraft-backed authentication.
 </Card>
+
+<Card title="ExternalDNS Bunny Webhook" icon="globe" href="/platform/external-dns-bunny-webhook">
+  ExternalDNS webhook provider that manages Bunny.net DNS records from Kubernetes Services and Ingresses.
+</Card>
 </CardGroup>
 
 <Note>


### PR DESCRIPTION
## Summary
- Adds three Mintlify pages under \`platform/external-dns-bunny-webhook\`: overview, installation, and configuration.
- Installation covers Helm deployment via the official \`kubernetes-sigs/external-dns\` chart, secret handling for \`BUNNY_API_KEY\`, and a verification step.
- Configuration documents all runtime environment variables (webhook and health endpoints, dry-run, timeouts) and every Bunny-specific annotation including Smart DNS latency and geo routing.
- Wires the pages into \`docs.json\` as a new **ExternalDNS Bunny Webhook** group under the Platform tab and adds a card to \`platform/index.mdx\`.

Style follows the existing \`platform/keycloak-minecraft-idp\` pages (Steps, Accordions for troubleshooting, Tooltips for domain terms, CardGroup for cross-links).

## Test plan
- [ ] \`mintlify dev\` renders all three new pages without broken internal links
- [ ] \`docs.json\` parses as valid JSON (verified locally)
- [ ] Navigation shows **ExternalDNS Bunny Webhook** as a group under Platform
- [ ] \`platform/index.mdx\` shows the new card

🤖 Generated with [Claude Code](https://claude.com/claude-code)