### PR TITLE
feat(build): add Build tab with Grounds dev-platform onboarding

### DIFF
--- a/build/ci-tokens.mdx
+++ b/build/ci-tokens.mdx
@@ -1,0 +1,97 @@
+---
+title: "CI / service-account tokens"
+description: "Long-lived, project-scoped API tokens for CI, scripts, and bots."
+---
+
+For unattended use you don't want to log a CI runner into a personal account — passwords expire, MFA breaks scripts, and a personal token would have access to **all** your projects. The platform mints **service-account tokens** instead: opaque, project-scoped, owner-mintable.
+
+## Format
+
+```
+gnds_<8-char-prefix>_<32-char-secret>
+```
+
+The prefix is logged for audit; the secret is shown **once** at mint time and stored as a SHA-256 hash by forge.
+
+## Permissions
+
+A service-account token can do anything an `editor` can do — within the project that minted it. Specifically:
+
+- ✓ Create pushes (`grounds push`)
+- ✓ Retry pushes
+- ✓ List, show, pin, unpin previews
+- ✓ Read deployment logs
+
+What it **cannot** do (privilege-escalation guard):
+
+- ✗ Mint another service-account token
+- ✗ Revoke a service-account token
+- ✗ Add or remove project members
+- ✗ Change member roles
+
+These are reserved for `owner` accounts, which means a leaked token can't be used to entrench itself. Rotate by minting a new one and revoking the old.
+
+## Minting
+
+Only project **owners** can mint.
+
+### Portal
+
+1. Open the project.
+2. **Settings** → **Service accounts**.
+3. Click **New token**, name it (`ci-github-actions`, `release-bot`), pick an expiry.
+4. Copy the secret immediately — you won't see it again.
+
+### CLI (forthcoming)
+
+```bash
+grounds project tokens create --name=ci-github-actions --expires-in=90d
+```
+
+## Using a token
+
+Set `GROUNDS_TOKEN` and the CLI/Gradle plugin will prefer it over `credentials.json`:
+
+```bash
+export GROUNDS_TOKEN=gnds_abc12345_…
+grounds push --target=staging
+```
+
+```yaml .github/workflows/push.yml
+env:
+  GROUNDS_TOKEN: ${{ secrets.GROUNDS_TOKEN }}
+```
+
+The token's project scope is **enforced by forge** — even if you pass `--project <other-id>`, forge ignores it and uses the token's scoped project.
+
+## Listing & revoking
+
+Owners can list active tokens (the secret is never returned, just the prefix and metadata):
+
+```
+PREFIX     NAME                   CREATED      LAST USED   EXPIRES
+gnds_abc1  ci-github-actions      2026-04-12   2026-04-28  2026-07-12
+gnds_def2  release-bot            2026-03-01   2026-04-27  never
+```
+
+Revoke from the portal or via API. Revocation is immediate — the token is rejected on the next request.
+
+## Expiry
+
+Tokens have a creation timestamp, optional expiry, and a `lastUsedAt` updated on every successful API call. The portal will surface tokens unused for >30 days for cleanup.
+
+<Note>
+Tokens never auto-rotate. The platform doesn't refresh them or reissue silently. Plan to rotate on a cadence (90d is a sensible default) by minting new + cutting over CI secrets + revoking old.
+</Note>
+
+## Audit
+
+Every token mint, use, and revocation is recorded in the project's audit feed (portal **Settings** → **Audit**). Useful when investigating a compromise or wondering "who pushed at 3am yesterday".
+
+## What if my token leaks?
+
+1. **Revoke immediately** in the portal. The token stops working on the next API call.
+2. Mint a new one and update CI secrets.
+3. Check the audit feed for unexpected pushes between leak and revocation.
+
+Because tokens are project-scoped and can't escalate, blast radius is limited to that project. A leaked token cannot mint more tokens or grant itself access elsewhere.

--- a/build/cli/auth.mdx
+++ b/build/cli/auth.mdx
@@ -1,0 +1,90 @@
+---
+title: "Auth"
+description: "Login, logout, doctor — and how the CLI talks to Grounds SSO."
+---
+
+The CLI authenticates against **Grounds SSO** using the OAuth 2.0 [device authorization grant](https://datatracker.ietf.org/doc/html/rfc8628) with PKCE. You don't need a client secret on your machine.
+
+## grounds login
+
+```bash
+grounds login
+```
+
+What happens:
+
+1. The CLI requests a device code from Grounds SSO.
+2. Your browser opens at the verification URL with the code pre-filled.
+3. You sign in (or are already signed in) and approve the device.
+4. The CLI exchanges the code for an access + refresh token.
+5. Tokens are written to your OS-specific config dir.
+
+The access token has a short lifetime (≈5 minutes). The refresh token lives ≈30 days. The CLI **transparently refreshes** the access token before each API call, so you log in once a month at most.
+
+## grounds logout
+
+```bash
+grounds logout
+```
+
+Deletes the credentials file. It does **not** revoke the refresh token at the IdP — it just removes the local copy. If you want a hard revoke, use the **Devices** page in `account.grounds.gg`.
+
+## grounds doctor
+
+```bash
+grounds doctor
+```
+
+Five checks, each reports OK or the failure reason:
+
+| Check | Verifies |
+|---|---|
+| `config` | Config dir is readable |
+| `auth` | Credentials present and the access token can be obtained (refreshes if expired) |
+| `api` | `<api>/healthz` returns 200 |
+| `gradle` | A Gradle wrapper or `gradle` binary is on PATH |
+| `java` | A JVM ≥ 21 is on PATH |
+
+`auth` will say `not logged in` if you've never run `login`, or `session expired (run 'grounds login')` if your refresh token has aged out.
+
+## Auth in CI / scripts
+
+For unattended use, **don't** run `grounds login`. Use a project-scoped service-account token instead:
+
+```bash
+export GROUNDS_TOKEN=gnds_abc123…   # opaque, project-scoped
+grounds push --target=staging
+```
+
+See [CI / service-account tokens](/build/ci-tokens) for how to mint one.
+
+`GROUNDS_TOKEN` overrides credentials from disk. The CLI will **not** try to refresh it (it's not a JWT).
+
+## Credentials on disk
+
+| OS | Path |
+|---|---|
+| Linux | `$XDG_CONFIG_HOME/grounds/credentials.json` (default `~/.config/grounds/credentials.json`) |
+| macOS | `~/Library/Application Support/grounds/credentials.json` |
+| Windows | `%APPDATA%\grounds\credentials.json` |
+
+The file holds the access token, refresh token, expiry timestamps, and a hint of who you are (email, preferred username decoded from the ID token). Permissions are `0600` on POSIX.
+
+<Warning>
+Don't commit this file or copy it to a CI runner. For any non-interactive use, use a service-account token.
+</Warning>
+
+## Multiple accounts / environments
+
+Use `--config <dir>` (or `GROUNDS_CONFIG_DIR`) to keep separate credential stores:
+
+```bash
+grounds --config ~/.config/grounds-prod login
+grounds --config ~/.config/grounds-staging login
+```
+
+The same flag selects which set is used by all subsequent commands.
+
+## API URL override
+
+Set `--api-url <url>` or `GROUNDS_API_URL` to talk to a different forge instance (e.g., a self-hosted preview). Default is `https://platform.grnds.io`.

--- a/build/cli/configuration.mdx
+++ b/build/cli/configuration.mdx
@@ -1,0 +1,81 @@
+---
+title: "Configuration"
+description: "Where the CLI looks for its config — files, env vars, and flag precedence."
+---
+
+The CLI is configured through a small handful of files, environment variables, and command-line flags. They compose with a strict precedence order.
+
+## Precedence
+
+For every setting, the first source that has a value wins:
+
+1. **Command-line flag** (`--api-url`, `--project`, …)
+2. **Environment variable** (`GROUNDS_API_URL`, `GROUNDS_PROJECT`, …)
+3. **Config file** (`config.toml` in the config dir)
+4. **Built-in default** (e.g., `https://platform.grnds.io`)
+
+## Config dir
+
+| OS | Default path | Override |
+|---|---|---|
+| Linux | `$XDG_CONFIG_HOME/grounds/` (default `~/.config/grounds/`) | `--config <dir>` or `GROUNDS_CONFIG_DIR` |
+| macOS | `~/Library/Application Support/grounds/` | same |
+| Windows | `%APPDATA%\grounds\` | same |
+
+What lives there:
+
+| File | Owner |
+|---|---|
+| `credentials.json` | Created by `grounds login`. Refresh + access tokens. `0600`. |
+| `config.toml` | Optional. User-managed defaults. |
+
+## config.toml
+
+Optional. Persistent overrides for things you don't want to type or set every shell.
+
+```toml ~/.config/grounds/config.toml
+api_url = "https://platform.grnds.io"
+project = "01J9K8…"
+output  = "table"
+```
+
+Every field is optional. Missing fields fall back to env or built-in default.
+
+## Environment variables
+
+| Var | Equivalent flag | Purpose |
+|---|---|---|
+| `GROUNDS_API_URL` | `--api-url` | forge endpoint |
+| `GROUNDS_PROJECT` | `--project` | project ID |
+| `GROUNDS_TOKEN` | (none) | Bearer token override (e.g., service-account `gnds_*`) |
+| `GROUNDS_CONFIG_DIR` | `--config` | Config dir |
+| `NO_COLOR` | `--no-color` | Disable ANSI colors |
+
+`GROUNDS_TOKEN` is special: when set, the CLI **skips** reading `credentials.json` entirely and uses the token verbatim. It will not be refreshed. This is the right knob for CI.
+
+## Profiles (advanced)
+
+For switching between multiple Grounds environments (e.g., staging vs prod self-hosted), keep separate config dirs:
+
+```bash
+alias grounds-prod='grounds --config ~/.config/grounds-prod'
+alias grounds-staging='grounds --config ~/.config/grounds-staging'
+
+grounds-prod login
+grounds-staging login
+
+grounds-prod push --target=staging
+```
+
+Each dir has its own `credentials.json` and `config.toml`.
+
+## Resetting
+
+To start completely fresh:
+
+```bash
+grounds logout                    # delete credentials only
+rm -rf ~/.config/grounds          # nuke everything
+```
+
+The CLI will recreate the config dir on next use.

--- a/build/cli/installation.mdx
+++ b/build/cli/installation.mdx
@@ -1,0 +1,84 @@
+---
+title: "Installing the CLI"
+description: "Install the grounds CLI on macOS, Linux, or Windows."
+---
+
+The `grounds` CLI is a single static Go binary. No JVM, no Node, no system dependencies.
+
+## Install
+
+<Tabs>
+<Tab title="macOS (Homebrew)">
+```bash
+brew install groundsgg/tap/grounds
+```
+
+Upgrade:
+
+```bash
+brew upgrade grounds
+```
+</Tab>
+<Tab title="Linux / WSL (script)">
+```bash
+curl -fsSL https://get.grnds.io/install.sh | sh
+```
+
+This installs to `/usr/local/bin/grounds` (or `~/.local/bin` if you `sh -s -- --prefix=$HOME/.local`).
+
+Upgrade by re-running the same command.
+</Tab>
+<Tab title="Windows (scoop)">
+```powershell
+scoop bucket add groundsgg https://github.com/groundsgg/scoop-bucket
+scoop install grounds
+```
+</Tab>
+<Tab title="Manual download">
+Grab the binary for your OS/arch from the [GitHub releases page](https://github.com/groundsgg/grounds-cli/releases) and put it on your `PATH`.
+
+```bash
+chmod +x grounds
+mv grounds /usr/local/bin/
+```
+</Tab>
+<Tab title="From source">
+```bash
+go install github.com/groundsgg/grounds-cli/cmd/grounds@latest
+```
+
+Requires Go 1.23+.
+</Tab>
+</Tabs>
+
+## Verify
+
+```bash
+grounds version
+grounds doctor
+```
+
+`grounds doctor` runs five checks: `config`, `auth`, `api`, `gradle`, `java`. The `gradle` and `java` checks are advisory — you only need them for actually pushing.
+
+## Shell completion
+
+Generate completion scripts on demand:
+
+```bash
+grounds completion bash > /etc/bash_completion.d/grounds          # bash
+grounds completion zsh  > "${fpath[1]}/_grounds"                  # zsh
+grounds completion fish > ~/.config/fish/completions/grounds.fish # fish
+```
+
+## Updating
+
+The CLI checks for updates lazily and prints a banner when a newer version is published. There is no auto-upgrade — use your installer of choice (brew, scoop, the install script).
+
+## What's where after install
+
+| Path | Purpose |
+|---|---|
+| `~/.config/grounds/` (Linux), `~/Library/Application Support/grounds/` (macOS), `%APPDATA%\grounds\` (Windows) | Config + credentials |
+| `$XDG_CACHE_HOME/grounds/` | Resolved API metadata cache |
+
+Override with `--config <dir>` or `GROUNDS_CONFIG_DIR`.

--- a/build/cli/preview.mdx
+++ b/build/cli/preview.mdx
@@ -1,0 +1,82 @@
+---
+title: "grounds preview"
+description: "List, inspect, and pin staging preview environments."
+---
+
+The `preview` subtree manages [preview environments](/build/concepts/preview-environments) — the ephemeral envs created by `grounds push --target=staging`.
+
+## Synopsis
+
+```text
+grounds preview list   [--include-deleted]
+grounds preview show   <id> [--json]
+grounds preview pin    <id>
+grounds preview unpin  <id>
+```
+
+All preview commands are scoped to the current project (use `--project` or `GROUNDS_PROJECT` to switch).
+
+## preview list
+
+```bash
+grounds preview list
+```
+
+```
+ID        PUSH      NAME          TYPE          STATUS  PINNED  EXPIRES     URL
+abc12345  def67890  my-plugin     plugin-paper  ready   no      2026-05-05  minecraft://my-plugin-prabc12345.mc.grnds.io
+…
+```
+
+| Flag | Purpose |
+|---|---|
+| `--include-deleted` | Show envs the janitor has already swept. Their `STATUS` will read `deleted`. |
+| `--output json` | Machine-readable form. Useful for piping into `jq`. |
+
+## preview show
+
+```bash
+grounds preview show abc12345
+```
+
+```
+ID:        abc12345-…
+PushID:    def67890-…
+Namespace: preview-abc12345
+Name:      my-plugin (plugin-paper)
+Status:    ready
+Pinned:    false
+Expires:   2026-05-05T14:23:00Z
+URL:       minecraft://my-plugin-prabc12345.mc.grnds.io
+```
+
+Add `--json` for the raw API response — useful for scripting or debugging.
+
+## preview pin / unpin
+
+```bash
+grounds preview pin <id>     # skip TTL janitor
+grounds preview unpin <id>   # re-enable TTL sweep
+```
+
+Pinned envs stay alive past their original `expiresAt`. They don't get a new TTL — they just don't have one. Unpin to put it back on the cleanup schedule (the TTL is recomputed from `now() + 7d`).
+
+<Note>
+Pinning is intentionally manual. The platform doesn't auto-pin "interesting" envs, so a forgotten demo doesn't quietly burn cluster resources for weeks.
+</Note>
+
+## What you can't do here (yet)
+
+- Force-delete a non-pinned env (the janitor will get to it within 30 min of expiry, and you can always push a new one).
+- Rename a preview env or change its hostname.
+- Promote a preview to production (that's a separate `grounds promote` flow, currently in beta).
+
+## Equivalents in the portal
+
+The portal's **Previews** tab on a project page has the same operations:
+
+- One row per env with status badge, expiry, public URL, pin indicator.
+- Per-row dropdown: **Pin (skip auto-cleanup)** / **Unpin (re-enable cleanup)**.
+- Click the URL to open the env in a new tab.
+
+Use whichever surface fits your flow — they hit the same forge endpoints.

--- a/build/cli/push.mdx
+++ b/build/cli/push.mdx
@@ -1,0 +1,108 @@
+---
+title: "grounds push"
+description: "Build with Gradle, upload to forge, deploy to a target."
+---
+
+`grounds push` is the command you'll run dozens of times a day. It's a thin wrapper over the [Gradle plugin](/build/gradle-plugin/setup): the CLI invokes `./gradlew groundsPush` with the right arguments and inherits its stdout.
+
+## Synopsis
+
+```text
+grounds push [--target=dev|staging] [--project <id>]
+grounds push retry <pushId>
+grounds push list [--target T] [--status S] [--limit N]
+```
+
+## push
+
+```bash
+grounds push --target=dev       # default
+grounds push --target=staging
+```
+
+Runs `./gradlew groundsPush --target=<t>` in the current directory. The Gradle plugin handles:
+
+- Resolving the JAR (auto-detects `shadowJar` or `jar`).
+- Reading and validating `grounds.yaml`.
+- Uploading JAR + manifest to forge.
+- Streaming build + deploy logs back to your terminal.
+- Exiting with a non-zero code on any terminal failure.
+
+The CLI exits with the same code Gradle exits with.
+
+## push retry
+
+```bash
+grounds push retry <pushId>
+```
+
+Re-runs the pipeline for a previously failed push. Forge re-uses the server-stored JAR and manifest, so this doesn't re-upload — it goes straight from `pending` to `building`. Use it when:
+
+- A build failed because of a transient infra issue (image pull, registry hiccup).
+- A deploy failed and you want to try again without rebuilding.
+
+The retry creates a **new** push row with its own ID; the original is preserved for history.
+
+## push list
+
+```bash
+grounds push list                          # last 20 in current project
+grounds push list --target=staging
+grounds push list --status=ready
+grounds push list --limit=50
+grounds push list --output=json | jq .
+```
+
+| Flag | Purpose |
+|---|---|
+| `--target` | Filter by target: `dev`, `staging`, `production`. |
+| `--status` | Filter by state: `pending`, `building`, `build_failed`, `build_succeeded`, `deploying`, `deploy_failed`, `ready`. |
+| `--limit` | Max rows to fetch (default 20, server cap 200). |
+| `--output` | `table` (default), `json`, or `yaml`. |
+
+## Common flags
+
+These are all global flags and apply to every subcommand:
+
+| Flag | Env | Purpose |
+|---|---|---|
+| `--project <id>` | `GROUNDS_PROJECT` | Pin the project for this call |
+| `--api-url <url>` | `GROUNDS_API_URL` | Override the forge endpoint |
+| `--config <dir>` | `GROUNDS_CONFIG_DIR` | Override config dir |
+| `--output <fmt>` | — | `table` / `json` / `yaml` |
+| `--verbose` / `-v` | — | Debug logs to stderr |
+| `--no-color` | `NO_COLOR=1` | Disable ANSI colors |
+
+## Reading the output
+
+A successful push looks like:
+
+```
+→ uploading my-cool-plugin-0.1.0.jar (4.2 MB)
+✔ uploaded — pushId=018f9c12-…
+[build] step 1/5 …
+[build] step 5/5 done
+✔ build_succeeded — image registry.platform.grnds.io/my-cool-plugin@sha256:…
+[deploy] reconciling deployment my-cool-plugin in user-hendrik
+[deploy] pod scheduled
+[deploy] pod ready
+✔ ready — connect at my-cool-plugin-hendrik.mc.grnds.io
+```
+
+If the pod ends up `CrashLoopBackOff`, you'll see deploy logs streamed before the CLI gives up and prints `deploy_failed`. Tail the live deployment logs separately at any time:
+
+```bash
+grounds logs deployment my-cool-plugin
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | `ready` reached |
+| 1 | Generic failure (validation, network, config) |
+| 2 | `build_failed` |
+| 3 | `deploy_failed` |
+| 130 | Cancelled by user (Ctrl-C) |
+
+Anything non-zero is safe to fail a CI step on.

--- a/build/concepts/preview-environments.mdx
+++ b/build/concepts/preview-environments.mdx
@@ -1,0 +1,75 @@
+---
+title: "Preview environments"
+description: "Ephemeral, public, per-push environments — the result of every staging deploy."
+---
+
+Every `grounds push --target=staging` creates a **preview environment**: a fresh namespace, a fresh deployment, and a public URL. They're built for sharing — review apps, demos, end-to-end test runs against a real cluster.
+
+## Anatomy of a preview env
+
+| Property | Value |
+|---|---|
+| Namespace | `preview-<short-id>` (auto-generated) |
+| Hostname | `<manifest-name>-pr<short-id>.mc.grnds.io` (Minecraft) or `…dev.grnds.io` (`service` workloads) |
+| TTL | 7 days from creation, sweep runs every 30 min |
+| Quota | One ResourceQuota per env, defaults to project-level limits |
+| Network | Default-deny NetworkPolicy + explicit allows for ingress + DNS |
+
+The TTL clock starts at preview creation, not at push completion. A pinned preview has no TTL.
+
+## Listing your previews
+
+```bash
+grounds preview list
+```
+
+```
+ID        PUSH      NAME          TYPE          STATUS  PINNED  EXPIRES     URL
+abc12345  def67890  my-plugin     plugin-paper  ready   no      2026-05-05  minecraft://my-plugin-prabc12345.mc.grnds.io
+…
+```
+
+Add `--include-deleted` to see envs that were swept by the janitor.
+
+```bash
+grounds preview show <id>     # one env in detail
+grounds preview show <id> --json
+```
+
+## Pinning
+
+Pinning skips the TTL janitor — the env stays alive until you unpin or delete it explicitly. Useful for long-running demos or a staging environment a non-developer is using.
+
+```bash
+grounds preview pin <id>
+grounds preview unpin <id>
+```
+
+In the portal, the Previews page has a per-row dropdown with **Pin (skip auto-cleanup)** / **Unpin (re-enable cleanup)**.
+
+<Warning>
+Pinning indefinitely costs cluster resources. Pin sparingly — for demos that have an end date — and unpin when done. The platform team will follow up on long-pinned envs that look forgotten.
+</Warning>
+
+## Lifecycle internals
+
+When you push to `staging`, forge:
+
+1. Builds your image (same as `dev`).
+2. Creates a `PreviewEnv` row with a generated short ID.
+3. Provisions a `preview-<id>` namespace with quota + default-deny NetworkPolicy.
+4. Deploys the workload into that namespace.
+5. Configures an ingress at `<name>-pr<id>.mc.grnds.io` (Minecraft workloads) or `…dev.grnds.io` (`service` workloads).
+
+The `PreviewJanitor` runs every 30 minutes:
+
+- Lists all `PreviewEnv` rows where `expiresAt < now() AND deletedAt IS NULL AND pinned = false`.
+- Deletes the namespace (which cascades the deployment, ingress, etc.).
+- Sets `deletedAt` on the row so it stops being considered.
+
+Deleted preview envs remain in the database for audit; the portal hides them by default but `grounds preview list --include-deleted` will show them.
+
+## When *not* to use staging
+
+- Inner-loop iteration on your own machine — use `groundsTestLocal` instead. It's offline, free, and 5 seconds per cycle. See [Local development](/build/local-development).
+- Long-lived dev environments for one person — that's what `--target=dev` is for. It doesn't burn a fresh namespace per push.

--- a/build/concepts/projects-and-teams.mdx
+++ b/build/concepts/projects-and-teams.mdx
@@ -1,0 +1,64 @@
+---
+title: "Projects & teams"
+description: "Projects scope everything you do on the platform — pushes, previews, members, tokens."
+---
+
+Every push, preview, and token belongs to a **project**. A project is your collaboration unit: a set of members with roles, working on the same plugin or service.
+
+## Roles
+
+There are three roles, with strictly nested permissions:
+
+| Role | Push | View pushes | Manage previews | Invite / remove members | Mint tokens |
+|---|---|---|---|---|---|
+| `viewer` | — | ✓ | — | — | — |
+| `editor` | ✓ | ✓ | ✓ | — | — |
+| `owner` | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+Roles are project-scoped. You can be an `owner` on one project and a `viewer` on another.
+
+<Note>
+A project must always have at least one owner. Trying to demote or remove the last owner returns a `409 last owner protection` error from forge.
+</Note>
+
+## Default project
+
+When you sign up, a default project is created for you with you as the sole owner. You can create more from the portal or via API.
+
+CLI commands without a project flag use your default project. Pin a different one for a single command:
+
+```bash
+grounds --project <project-id> push
+```
+
+Or for the whole shell session:
+
+```bash
+export GROUNDS_PROJECT=<project-id>
+```
+
+## Inviting members
+
+There are two flows.
+
+### Add by username
+
+Owners can add a known account directly from the portal Members page. The user must have signed in at least once so we have a record of them.
+
+### Invite link
+
+For people who haven't signed up yet, mint a one-time invite link:
+
+1. **Portal** → Project → Members → **Invite link**.
+2. Pick the role (`editor` or `viewer`) and an expiry (default 7 days, max 30).
+3. Send the URL. The recipient signs in via Grounds SSO and is automatically added to the project.
+
+Invite links are **single-use** — redemption is atomic, so simultaneous clicks can't both succeed. They cannot be used to grant `owner` (only existing owners can promote).
+
+## Service-account tokens
+
+For unattended use (CI, scripts, bots) projects can mint long-lived `gnds_*` API tokens scoped to a single project. See [CI / service-account tokens](/build/ci-tokens).
+
+## Audit
+
+Membership and role changes are recorded in the project's audit feed (visible in the portal under Settings → Audit). Token mint and revocation events appear there too.

--- a/build/concepts/pushes.mdx
+++ b/build/concepts/pushes.mdx
@@ -1,0 +1,90 @@
+---
+title: "Pushes"
+description: "The lifecycle of a push — from upload to running pod."
+---
+
+A **push** represents one attempt to ship a JAR to a target. Each `grounds push` (or portal-initiated build) creates one Push row that you can inspect, retry, and tail logs from.
+
+## States
+
+A push moves through a small state machine. Forge persists the current state on the row and emits SSE events on transitions.
+
+```
+       upload
+         │
+         ▼
+     ┌────────┐         ┌────────────┐
+     │pending │ ──────► │ building   │
+     └────────┘         └─────┬──────┘
+                              │
+                  ┌───────────┴───────────┐
+                  ▼                       ▼
+          ┌──────────────────┐    ┌──────────────┐
+          │ build_succeeded  │    │ build_failed │
+          └────────┬─────────┘    └──────────────┘
+                   │
+                   ▼
+              ┌──────────┐         ┌────────────────┐
+              │deploying │ ──────► │ deploy_failed  │
+              └────┬─────┘         └────────────────┘
+                   │
+                   ▼
+                ┌──────┐
+                │ready │
+                └──────┘
+```
+
+| State | Meaning |
+|---|---|
+| `pending` | Manifest + JAR uploaded, build job not yet started. |
+| `building` | Kaniko is producing the OCI image from your JAR + base image. |
+| `build_failed` | Build error. JAR is still on the server; **retry** is supported. |
+| `build_succeeded` | Image pushed to the in-cluster registry; deployment hasn't started. |
+| `deploying` | Kubernetes is reconciling the new image. |
+| `deploy_failed` | Deployment failed (bad image pull, resource limits, crashloop). |
+| `ready` | Pod is up and serving. Terminal happy-path state. |
+
+`build_failed` and `deploy_failed` are terminal but **retryable**: forge keeps your JAR and manifest, so a retry doesn't re-upload.
+
+## Identity & idempotency
+
+Each push has:
+
+- A UUID (`id`) you'll see referenced everywhere — CLI output, portal URLs, log streams.
+- A **content hash** computed over the JAR + manifest. If you push the exact same bytes twice, forge re-uses the previous build instead of rebuilding from scratch.
+
+## Tailing logs
+
+Two log streams per push:
+
+```bash
+grounds logs <pushId>                   # build logs (kaniko)
+grounds logs deployment <name>          # runtime logs (the pod)
+```
+
+Both are SSE streams that follow until a terminal state, then close. Add `--no-follow` to get a snapshot and exit.
+
+## Retrying
+
+A failed build or failed deploy can be retried without re-uploading:
+
+```bash
+grounds push retry <pushId>
+```
+
+This creates a **new** push row that re-uses the server-stored JAR and manifest, then re-runs the pipeline from `pending`. The original failed push is preserved for history.
+
+## Listing
+
+```bash
+grounds push list                       # last 20 pushes in current project
+grounds push list --target=staging      # filter by target
+grounds push list --status=ready        # filter by terminal state
+```
+
+In the portal, the project's **Pushes** page shows the same list with status badges and clickable detail pages.
+
+## What survives a push
+
+- The previous deployment for `dev` is **replaced**. State (world chunks, plugin data files) survives because the volume is attached at the namespace level — but anything in-memory is lost.
+- For `staging`, each push creates a new preview env, so nothing survives across pushes; that's the point.

--- a/build/concepts/targets.mdx
+++ b/build/concepts/targets.mdx
@@ -1,0 +1,60 @@
+---
+title: "Targets"
+description: "Where a push lands — dev, staging, or production."
+---
+
+Every push is deployed to a **target**. The target picks the namespace, lifecycle, and visibility rules for the resulting deployment.
+
+## dev
+
+```bash
+grounds push --target=dev   # default
+```
+
+- **Lifecycle**: long-lived. Each push to `dev` rolls over the previous one.
+- **Namespace**: your personal namespace, `user-<your-handle>`.
+- **Visibility**: only you can connect. Reachable at `<name>-<your-handle>.mc.grnds.io` (Minecraft) or `<name>-<your-handle>.dev.grnds.io` (HTTPS for `service` workloads).
+- **Use it for**: your own iteration. Cheap, persistent, no public URL.
+
+This is the default and what you'll use most.
+
+## staging
+
+```bash
+grounds push --target=staging
+```
+
+- **Lifecycle**: ephemeral. Each push gets its **own** environment. Auto-deleted after **7 days** unless pinned.
+- **Namespace**: a fresh `preview-<id>` namespace per push.
+- **Visibility**: public. URL pattern `<name>-pr<id>.mc.grnds.io` for Minecraft workloads, `…dev.grnds.io` for `service`.
+- **Use it for**: review apps, sharing a build with a teammate, demoing a PR, end-to-end testing.
+
+Each staging push creates a [preview environment](/build/concepts/preview-environments) you can list with `grounds preview list`.
+
+## production
+
+Production deploys are not initiated by `grounds push`. They are **promoted** from a known-good staging push, with an explicit approval step.
+
+```
+grounds promote <pushId>   # not yet generally available
+```
+
+- **Lifecycle**: long-lived, single deployment per project.
+- **Visibility**: public. Routed via the project's configured production hostname.
+- **Use it for**: the actual customer-facing release.
+
+<Note>
+The `grounds promote` flow is currently restricted while we finalize the approval policy. Reach out in `#grounds-platform` if you need it for an early customer rollout.
+</Note>
+
+## Choosing a target
+
+| Question | Target |
+|---|---|
+| "I want to test my own change quickly." | `dev` |
+| "I want to share a build with a teammate or non-developer." | `staging` |
+| "I want to release to customers." | `production` (via promote) |
+
+## Quotas
+
+Each project has per-target quotas (CPU, memory, concurrent staging envs). You hit them rarely; the portal's project page shows current usage. Bumps are a `#grounds-platform` request away.

--- a/build/gradle-plugin/groundsPush.mdx
+++ b/build/gradle-plugin/groundsPush.mdx
@@ -1,0 +1,91 @@
+---
+title: "groundsPush"
+description: "The main upload + build + deploy task."
+---
+
+```bash
+./gradlew groundsPush                       # default target
+./gradlew groundsPush --target=staging
+./gradlew groundsPush --target=dev
+```
+
+This is the task the CLI's `grounds push` invokes under the hood. Run it directly when you don't have the CLI on your machine, or from CI.
+
+## What it does
+
+1. **Validate** — parses `grounds.yaml`, checks required fields.
+2. **Resolve JAR** — uses the `jarFile` extension property, or auto-detected `shadowJar`/`jar` output. Builds it if needed (this task `dependsOn` the JAR task).
+3. **Upload** — multipart POST of the JAR + manifest to `<apiUrl>/v1/pushes`. Returns a push ID.
+4. **Stream** — opens an SSE connection to `<apiUrl>/v1/pushes/<id>/logs` and tails until terminal status.
+5. **Exit** — fails the build (non-zero exit) on `build_failed` or `deploy_failed`. Logs the public URL on `ready`.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--target=<dev\|staging>` | Override the manifest's target. **Highest precedence**. |
+
+That's it. Everything else is configured via the [`groundsPush` extension](/build/gradle-plugin/setup#the-groundspush-extension) or `grounds.yaml`.
+
+## Output
+
+```
+> Task :groundsPush
+[grounds-push] uploading my-plugin-0.1.0-all.jar (4.2 MB)
+[grounds-push] pushId=018f9c12-…
+[build] step 1/5 …
+[build] step 5/5 done — image registry.platform.grnds.io/my-plugin@sha256:…
+[deploy] reconciling deployment
+[deploy] pod scheduled
+[deploy] pod ready
+[grounds-push] ✔ ready — connect at my-plugin-hendrik.mc.grnds.io
+```
+
+When run via `grounds push`, the CLI re-rendres these messages with colour and progress indicators. As a raw Gradle task it's plaintext.
+
+## Failure handling
+
+The build fails on:
+
+- Manifest parse error (caught locally before upload).
+- Upload error (network, 4xx from forge, file not found).
+- Terminal `build_failed` or `deploy_failed` from the SSE stream.
+- Connection lost for longer than `timeoutMinutes` (default 5).
+- Whitelist warning when `failOnWhitelistError = true` (the default).
+
+Each prints a `GradleException` with the diagnostic from forge. For build/deploy failures, the message includes the push ID so you can re-run with `groundsPushRetry` or fetch logs separately.
+
+## Inputs / outputs (Gradle terms)
+
+| Property | Type | Default |
+|---|---|---|
+| `manifestFile` | `RegularFileProperty` (input) | `<projectDir>/grounds.yaml` |
+| `jarFile` | `RegularFileProperty` (input) | auto from `shadowJar` / `jar` |
+| `apiUrl` | `Property<String>` (input) | from credentials, else `https://platform.grnds.io` |
+| `target` | `Property<String>` (input) | `dev` |
+| `timeoutMinutes` | `Property<Int>` | `5` |
+| `connectTimeoutSeconds` | `Property<Int>` | `20` |
+| `failOnWhitelistError` | `Property<Boolean>` | `true` |
+
+This task has no Gradle outputs and is not cacheable — it always re-runs (a push is by definition not idempotent, even though forge dedupes by content hash).
+
+## Calling from CI
+
+```yaml .github/workflows/push.yml
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - run: ./gradlew :plugin:groundsPush --target=staging
+        env:
+          GROUNDS_TOKEN: ${{ secrets.GROUNDS_TOKEN }}
+          GITHUB_ACTOR:  ${{ github.actor }}
+          GITHUB_TOKEN:  ${{ secrets.GITHUB_TOKEN }}      # for plugin pull
+```
+
+`GROUNDS_TOKEN` should be a [service-account token](/build/ci-tokens) scoped to the project. Don't use a personal user token — it has too-broad permissions and can't be rotated independently.

--- a/build/gradle-plugin/groundsPushRetry.mdx
+++ b/build/gradle-plugin/groundsPushRetry.mdx
@@ -1,0 +1,51 @@
+---
+title: "groundsPushRetry"
+description: "Re-run a failed pipeline without re-uploading the JAR."
+---
+
+```bash
+./gradlew groundsPushRetry --pushId=<id>
+```
+
+Re-runs the build/deploy pipeline for a previously failed push. Forge already has the JAR and manifest on disk, so this is **upload-free** — straight from `pending` to `building`.
+
+## When to use it
+
+- A build failed because of a transient infra issue (registry timeout, image pull error).
+- A deploy failed and you want to try again without rebuilding the image.
+- You're in CI and want a quick retry without re-running the entire Gradle build.
+
+If you've changed code and want a fresh build, use `groundsPush` instead — `groundsPushRetry` would deploy your old bytes.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--pushId=<id>` | The ID of the failed push to retry. **Required.** |
+
+The push must be in a retryable state (`build_failed` or `deploy_failed`). Forge will reject retries against `ready`, `pending`, or `building` pushes with a 409.
+
+## What it does
+
+1. POST to `<apiUrl>/v1/pushes/<pushId>/retry` — forge creates a new push row with the same content hash.
+2. Stream the new push's logs the same way `groundsPush` does.
+3. Exit non-zero on terminal failure of the **retry** push.
+
+## Output
+
+```
+> Task :groundsPushRetry
+[grounds-push] retrying 018f9c12-… as 018f9d04-…
+[build] step 1/5 …
+[build] step 5/5 done
+[deploy] pod ready
+[grounds-push] ✔ ready
+```
+
+## CLI equivalent
+
+```bash
+grounds push retry <pushId>
+```
+
+Same operation. Use whichever is convenient.

--- a/build/gradle-plugin/groundsTestLocal.mdx
+++ b/build/gradle-plugin/groundsTestLocal.mdx
@@ -1,0 +1,81 @@
+---
+title: "groundsTestLocal"
+description: "Run Paper or Velocity locally with your plugin loaded — no cloud, no quota."
+---
+
+```bash
+./gradlew groundsTestLocal
+```
+
+Spins up a Paper or Velocity server **on your laptop** with this build's plugin JAR pre-installed. The cloud equivalent is `grounds push --target=dev`; this is the **offline** development loop — no Grounds infra is touched, no quota is consumed, no cluster is needed.
+
+## When to use it
+
+| Use this when | Use `grounds push --target=dev` when |
+|---|---|
+| Iterating on plugin logic alone. | You need the full forge runtime (eg. config plugin, social plugin) loaded. |
+| Offline / on the train. | You want to share with a teammate. |
+| You don't want to wait for a build + deploy round-trip. | You're testing inter-service interactions. |
+| You're new and not yet authed. | You're testing routing, ingress, or anything network-shaped. |
+
+For pure plugin-logic iteration, `groundsTestLocal` is **5× faster** than a cloud push (no network upload, no Kaniko, no Kube reconcile).
+
+## Requirements
+
+- JDK 21+ on `PATH`.
+- An internet connection on the **first** run (to download Paper / Velocity from `api.papermc.io`). Subsequent runs are fully offline.
+
+## What happens
+
+1. Reads `grounds.yaml`, finds `baseImage`.
+2. If `paper` or `velocity`: downloads the latest stable build of that version from PaperMC's v2 API. Caches under `build/grounds-test/cache/`.
+3. Sets up a server directory at `build/grounds-test/<baseImage>-<version>/`. Persists between runs, so player data + world chunks survive.
+4. For Paper: writes `eula.txt` (signed) and a sane `server.properties` on first run (online-mode=false, view-distance=8, no spawn protection). Edits stick.
+5. Drops your plugin JAR into `plugins/`.
+6. `java -jar` starts the server with stdin/stdout attached. Ctrl-C shuts it down cleanly.
+
+## Output
+
+```
+> Task :groundsTestLocal
+[grounds-test] downloading paper-1.21.4-220.jar from PaperMC
+[grounds-test] installed my-plugin-0.1.0-all.jar into …/plugins
+[grounds-test] starting Paper 1.21.4 in …/build/grounds-test/paper-1.21.4
+[grounds-test] connect with: minecraft://localhost:25565 (paper) or 25577 (velocity)
+[server thread/INFO]: Starting Minecraft server on *:25565
+…
+```
+
+Connect from your client to `localhost:25565` (Paper) or `localhost:25577` (Velocity).
+
+## Configuration
+
+```kotlin build.gradle.kts
+groundsPush {
+    paperVersion.set("1.21.5")              // default 1.21.4
+    velocityVersion.set("3.4.0-SNAPSHOT")   // default
+}
+```
+
+Versions are resolved against PaperMC's v2 API at task run time, so any version they publish is fair game.
+
+## Limitations (v0)
+
+- Only `baseImage: paper` and `baseImage: velocity` are supported. `minestom` and `service` workloads need `grounds push --target=dev` — they're plain JVM apps, not Minecraft servers, and we don't ship a generic local runner.
+- No multi-plugin compose. Only **this build's** JAR gets auto-installed; if you manually drop other JARs into `plugins/`, they'll persist between runs (the task only re-installs its own JAR each time).
+- Local data is just a directory. Wipe with `./gradlew clean` (or `rm -rf build/grounds-test/`) for a fresh world.
+
+## What does *not* happen
+
+- No Kaniko build. Your raw JAR is loaded directly — same as `./gradlew build` then dropping it manually into a Paper server's `plugins/`.
+- No quota / push-history record. This task talks to **no** Grounds infra.
+- No public URL. It's `localhost`. Use `staging` if you need a sharable URL.
+
+## Combining with `groundsPush`
+
+A reasonable inner-to-outer-loop:
+
+1. `./gradlew groundsTestLocal` — iterate locally until it works.
+2. `grounds push --target=dev` — verify it works inside the platform's runtime (config plugin, social plugin, etc.).
+3. `grounds push --target=staging` — share with a teammate.
+4. `grounds promote <pushId>` — release.

--- a/build/gradle-plugin/setup.mdx
+++ b/build/gradle-plugin/setup.mdx
@@ -1,0 +1,138 @@
+---
+title: "Setup"
+description: "Apply gg.grounds.push to your Gradle project."
+---
+
+The `gg.grounds.push` Gradle plugin is what actually uploads your JAR to forge. The CLI's `grounds push` is a thin wrapper around its tasks.
+
+<Note>
+`gg.grounds.push` is **separate** from the convention-plugin bundle (`gg.grounds.paper-conventions`, `gg.grounds.kotlin-conventions`, …). The conventions plugins shape your build; `push` ships its output. You almost certainly want both.
+</Note>
+
+## Prerequisites
+
+- A GitHub personal access token with `read:packages` scope (the plugin lives on GitHub Packages).
+- Gradle 8+ and JDK 21+.
+- A `shadowJar` or `jar` task that produces the artifact you want to push.
+
+## Add the plugin repository
+
+In `settings.gradle.kts`:
+
+```kotlin settings.gradle.kts
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven {
+            url = uri("https://maven.pkg.github.com/groundsgg/grounds-push")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR") ?: providers.gradleProperty("github.user").get()
+                password = System.getenv("GITHUB_TOKEN") ?: providers.gradleProperty("github.token").get()
+            }
+        }
+    }
+}
+```
+
+Storing creds in `~/.gradle/gradle.properties`:
+
+```properties ~/.gradle/gradle.properties
+github.user=your-github-handle
+github.token=ghp_…
+```
+
+## Apply the plugin
+
+In your **plugin module's** `build.gradle.kts` (the one that produces the JAR):
+
+```kotlin build.gradle.kts
+plugins {
+    id("gg.grounds.push") version "0.5.0"
+}
+```
+
+That's it. The plugin registers four tasks:
+
+| Task | Purpose |
+|---|---|
+| [`groundsPush`](/build/gradle-plugin/groundsPush) | Upload + build + deploy. |
+| [`groundsPushRetry`](/build/gradle-plugin/groundsPushRetry) | Re-run a failed pipeline using server-stored JAR. |
+| `groundsPromote` | Promote a successful push to a higher target (currently in beta). |
+| [`groundsTestLocal`](/build/gradle-plugin/groundsTestLocal) | Run Paper/Velocity locally with this plugin loaded — offline dev loop. |
+
+## The `groundsPush` extension
+
+For most projects you don't need to touch this — the plugin auto-detects everything. But it's useful for power users:
+
+```kotlin build.gradle.kts
+groundsPush {
+    apiUrl.set("https://platform.grnds.io")     // optional override; default is from credentials.json
+    manifestFile.set(file("grounds.yaml"))      // default: <projectDir>/grounds.yaml
+    jarFile.set(tasks.named<Jar>("shadowJar").flatMap { it.archiveFile })  // auto-detected
+    target.set("dev")                            // overrides grounds.yaml target
+    timeoutMinutes.set(5)                        // SSE inactivity timeout
+    connectTimeoutSeconds.set(20)                // initial HTTP connect timeout
+    failOnWhitelistError.set(true)               // any whitelist warning fails the build
+
+    // groundsTestLocal-only:
+    paperVersion.set("1.21.4")                   // default
+    velocityVersion.set("3.4.0-SNAPSHOT")        // default
+}
+```
+
+All fields are optional. Defaults match what `grounds push` from the CLI uses.
+
+## JAR auto-detection
+
+At `afterEvaluate`, the plugin looks for tasks named (in order) `shadowJar`, `jar`, and wires the first one found as both the JAR source and a build dependency. So:
+
+```kotlin build.gradle.kts
+plugins {
+    id("com.gradleup.shadow") version "8.3.5"
+    id("gg.grounds.push") version "0.5.0"
+}
+
+tasks.shadowJar {
+    archiveClassifier.set("")
+}
+```
+
+is everything you need — `groundsPush` will:
+
+1. Trigger `shadowJar`.
+2. Read its output JAR.
+3. Upload it.
+
+Override `jarFile` only if you have multiple JARs or use a non-standard packaging task.
+
+## Project layout
+
+The plugin runs **per Gradle project** (per `build.gradle.kts`). For a multi-module repo where only one module is the deployable, apply it only there:
+
+```text
+my-repo/
+├── settings.gradle.kts
+├── shared/
+│   └── build.gradle.kts          ← no grounds-push
+├── plugin/
+│   ├── build.gradle.kts          ← apply gg.grounds.push here
+│   ├── grounds.yaml              ← here
+│   └── src/…
+```
+
+Then run from the repo root:
+
+```bash
+./gradlew :plugin:groundsPush --target=staging
+```
+
+Or `cd plugin && grounds push --target=staging`.
+
+## Authentication
+
+The plugin reads a bearer token from, in order:
+
+1. `GROUNDS_TOKEN` environment variable.
+2. The credentials file written by `grounds login`.
+
+For CI, set `GROUNDS_TOKEN` to a [service-account token](/build/ci-tokens). Don't commit `credentials.json`.

--- a/build/index.mdx
+++ b/build/index.mdx
@@ -1,0 +1,83 @@
+---
+title: "Build for Grounds"
+description: "Ship your Minecraft plugin or game mode to managed Grounds infrastructure — without touching Kubernetes."
+---
+
+Grounds is a developer platform for Minecraft modders. You write a Paper plugin, Velocity plugin, or full game mode; we handle the cluster, the registry, the routing, and the lifecycle.
+
+## What you get
+
+<CardGroup cols={2}>
+<Card title="One-command deploys" icon="rocket">
+  `grounds push --target=dev` builds your JAR, ships it to a private OCI registry, and rolls out a fresh server in your personal namespace.
+</Card>
+
+<Card title="Ephemeral preview environments" icon="flask">
+  `grounds push --target=staging` spins up a throwaway preview env per push with a public URL — perfect for sharing a build with playtesters or your team.
+</Card>
+
+<Card title="Managed Minecraft routing" icon="network-wired">
+  Players connect to `<your-mode>-<handle>.mc.grnds.io` directly — no port forwarding, no proxy config. Service-type workloads get HTTPS at `<name>-<handle>.dev.grnds.io`.
+</Card>
+
+<Card title="Multi-project isolation" icon="folder-tree">
+  Group related deployments under a project. Invite teammates with owner/editor/viewer roles. Each project gets its own resource quotas + network policies.
+</Card>
+</CardGroup>
+
+## Who this is for
+
+You probably want this if you:
+
+- maintain a Paper or Velocity plugin and need a place to test it against real player traffic
+- are building a custom game mode (Minestom, Paper) and want preview links you can share
+- run a small studio/community where multiple devs want to publish their work without each running their own VPS
+
+You probably **don't** want this (yet) if you:
+
+- need control over the host OS or Java runtime version (we pin these)
+- want to run mods that require non-Paper/Velocity bases (the supported `baseImage` set is small today)
+- expect free tier with persistent always-on servers — Grounds auto-pauses idle dev clusters after a few hours
+
+## Get started in five minutes
+
+<Steps>
+<Step title="Install the CLI">
+  ```bash
+  brew install groundsgg/tap/grounds
+  ```
+
+  Linux/Windows + scripts: see [Quickstart → Install](/build/quickstart#install-the-cli).
+</Step>
+
+<Step title="Sign in">
+  ```bash
+  grounds login
+  ```
+
+  Browser opens to Grounds SSO; approve the device code and you're back at the terminal.
+</Step>
+
+<Step title="Push your project">
+  From any Gradle project that has `id("gg.grounds.push")` applied:
+
+  ```bash
+  grounds push --target=dev
+  ```
+
+  Forge builds and signs the OCI image, applies the manifest, and prints the public URL when ready.
+</Step>
+</Steps>
+
+[Full quickstart →](/build/quickstart)
+
+## What's under the hood
+
+Grounds runs on a self-hosted Kubernetes cluster (Talos on bare metal). Key building blocks:
+
+- **forge** — the control-plane API. Receives pushes, runs Kaniko + Cosign, applies manifests, manages dev-cluster lifecycle.
+- **grounds-push Gradle plugin** — packages your JAR + manifest into a multipart upload to forge.
+- **grounds CLI** — thin wrapper for auth, manual push, status, preview env management.
+- **Portal** — web UI at `portal.platform.grnds.io` for browsing pushes, deployments, members, and preview envs.
+
+You don't need to know any of this to ship — but it's there if you want to peek behind the curtain.

--- a/build/local-development.mdx
+++ b/build/local-development.mdx
@@ -1,0 +1,93 @@
+---
+title: "Local development"
+description: "Iterate on your plugin without round-tripping through the cloud."
+---
+
+The fastest dev loop is the one that doesn't leave your machine. The `groundsTestLocal` Gradle task spins up a **real** Paper or Velocity server with your plugin pre-loaded — no Grounds infra, no quota, no network round-trip.
+
+## The loop
+
+```bash
+./gradlew groundsTestLocal
+```
+
+That's the entire workflow. The task:
+
+1. Downloads Paper/Velocity from `api.papermc.io` (cached after first run).
+2. Sets up a server directory at `build/grounds-test/<baseImage>-<version>/`.
+3. Drops your build's JAR into `plugins/`.
+4. Starts `java -jar` with stdin/stdout attached.
+
+Connect from your Minecraft client to `localhost:25565` (Paper) or `localhost:25577` (Velocity).
+
+## When local *is* enough
+
+Local is the right loop for:
+
+- Plugin logic in isolation (commands, listeners, persistence).
+- Configuration parsing.
+- Anything you'd test with unit/integration tests in the JVM, but want to see in-game.
+
+## When local is *not* enough
+
+You'll need a cloud `dev` push when:
+
+- Your plugin depends on the **platform's runtime extras** (config plugin, social plugin, match plugin) that we layer on top of the base image in production. Locally you only get vanilla Paper.
+- You're testing **inter-service** behaviour — calls to grounds-forge APIs, Keycloak SSO, Grafana dashboards, Cosign-signed images.
+- You're testing **routing or ingress** — locally is just `localhost`.
+- You're sharing with someone who isn't on your laptop.
+
+The mental model: `groundsTestLocal` answers *"does my plugin work?"*; `grounds push --target=dev` answers *"does my plugin work on the platform?"*.
+
+## A typical day
+
+```bash
+# Edit code
+$ vim src/main/kotlin/...
+
+# Iterate locally — fast
+$ ./gradlew groundsTestLocal
+# Ctrl-C when done, edit again, re-run.
+
+# Once it works, push to dev to verify in-platform
+$ grounds push --target=dev
+
+# Ready to share?
+$ grounds push --target=staging
+# Send the URL to a teammate.
+```
+
+## State that survives between runs
+
+The server dir at `build/grounds-test/<base>-<version>/` persists between runs. That means:
+
+- World chunks survive — your test world isn't reset on restart.
+- `server.properties` edits stick — set difficulty / view-distance once.
+- Plugins you manually drop into `plugins/` survive (only **your** plugin's JAR is re-installed each run).
+
+To wipe state: `./gradlew clean` or `rm -rf build/grounds-test/`.
+
+## Configuration
+
+Override Paper / Velocity versions via the [`groundsPush` extension](/build/gradle-plugin/setup#the-groundspush-extension):
+
+```kotlin build.gradle.kts
+groundsPush {
+    paperVersion.set("1.21.5")
+    velocityVersion.set("3.4.0-SNAPSHOT")
+}
+```
+
+Pull tested versions from PaperMC's [downloads page](https://papermc.io/downloads/paper).
+
+## What about `gamemode` (Minestom) and `service` workloads?
+
+Currently unsupported in `groundsTestLocal`. Use `grounds push --target=dev` for those. They run as plain JVM apps, not Minecraft servers, so we don't ship a generic local runner.
+
+If you want this, ping `#grounds-platform` — there's an open question of whether a Minestom local runner adds enough value over `gradle run` from a Minestom main.
+
+## Network sandboxing
+
+The local server is exposed only on `127.0.0.1` by default — no firewall rules, no port forwarding. Your roommate's Minecraft client on the same Wi-Fi can't reach it (unless they have access to your dev box, which is a different problem).
+
+If you want a teammate elsewhere to play, push to staging.

--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -1,0 +1,120 @@
+---
+title: "Manifest reference"
+description: "Every field in grounds.yaml, what it does, and what's optional."
+---
+
+`grounds.yaml` lives at the root of your project and tells forge **what** you're pushing. It's read by both the Gradle plugin (to upload it) and forge (to build + deploy it).
+
+## Minimal example
+
+```yaml grounds.yaml
+name: my-plugin
+type: plugin-paper
+baseImage: paper
+```
+
+## Full example
+
+```yaml grounds.yaml
+name: my-plugin
+type: plugin-paper
+baseImage: paper
+jar: build/libs/my-plugin-*-all.jar
+target: dev          # optional default; CLI/Gradle override wins
+resources:
+  cpu: 500m
+  memory: 1Gi
+```
+
+## Fields
+
+### `name` (required)
+
+The logical app name. Used as:
+
+- The Kubernetes `Deployment` name (so it has to match `[a-z0-9-]{1,40}`).
+- The hostname prefix for staging previews (`<name>-pr<id>.mc.grnds.io` for Minecraft workloads, `…dev.grnds.io` for `service`).
+- The display name in the portal.
+
+Once you've pushed, **don't rename** — that creates a new app from forge's perspective and orphans the previous one. Rename via portal or contact `#grounds-platform` if you need to migrate state.
+
+### `type` (required)
+
+What kind of workload this is. One of:
+
+| Type | Workload | Base image options |
+|---|---|---|
+| `plugin-paper` | Bukkit/Paper plugin JAR | `paper` |
+| `plugin-velocity` | Velocity plugin JAR | `velocity` |
+| `gamemode` | Custom JAR running on Minestom | `minestom` |
+| `service` | Plain JVM app (no Minecraft runtime) | `service` |
+
+`type` drives quotas, resource defaults, port mappings, and which container our renderer wires up.
+
+### `baseImage` (required)
+
+The container base your JAR is layered onto. Must be one of the base images allowed for your `type`:
+
+| `baseImage` | Provided by | What it gives you |
+|---|---|---|
+| `paper` | `ghcr.io/groundsgg/paper` | A Paper server with sane defaults, your JAR auto-loaded into `plugins/`. |
+| `velocity` | `ghcr.io/groundsgg/velocity` | A Velocity proxy with your JAR in `plugins/`. |
+| `minestom` | `ghcr.io/groundsgg/minestom` | A bare Minestom runner that executes your JAR's `main`. |
+| `service` | `ghcr.io/groundsgg/jvm-service` | Generic JVM runner — your JAR's `main` is the entrypoint, no Minecraft runtime. |
+
+`paper` and `velocity` versions are pinned by the base-image release. To bump (e.g., from 1.21.4 → 1.21.5), bump the base-image tag, not your manifest.
+
+### `jar` (optional, default `build/libs/*.jar`)
+
+A glob pointing at the JAR to upload, **relative to the project root**. The Gradle plugin auto-detects `shadowJar` or `jar` and sets this for you, so you usually don't need to write it.
+
+When to set it explicitly:
+
+- You produce multiple JARs and want to ensure the right one is picked.
+- You build with something other than `shadowJar` / `jar`.
+
+### `target` (optional)
+
+A default target if neither the CLI flag nor the Gradle extension overrides it. Order of precedence:
+
+1. CLI flag: `grounds push --target=staging`
+2. Gradle extension: `groundsPush { target.set("staging") }`
+3. `grounds.yaml: target: ...`
+4. Fallback: `dev`
+
+You almost never want this in version control — it makes "what does pushing actually do?" non-obvious for teammates. Prefer the CLI flag.
+
+### `resources` (optional)
+
+CPU/memory request hints. They're **suggestions** — forge clamps them to the per-type minimums (e.g., `plugin-paper` is at least `250m` CPU and `1Gi` memory) and to per-project quota maxima. If your value falls inside the legal range, it's used as-is.
+
+```yaml
+resources:
+  cpu: 500m       # Kubernetes resource units: 500m = 0.5 vCPU
+  memory: 1Gi
+```
+
+Quirks worth knowing:
+
+- We always set `requests == limits`. Pods are deterministic and don't burst.
+- Below the minimum: silently raised to the minimum.
+- Above the project quota: push fails at admission with a quota error.
+
+### Other fields
+
+`grounds.yaml` is **strict**. Unknown top-level fields are rejected at parse time so typos don't silently get ignored. If you need something not covered here, open a `#grounds-platform` ticket — the parser only knows what's listed above.
+
+## Validation
+
+The Gradle plugin parses `grounds.yaml` before upload. Common errors:
+
+| Error | Fix |
+|---|---|
+| `missing required field 'name'` | Add `name`. |
+| `field 'name' must be a string` | Quote numeric-looking names. |
+| `'resources' must be a mapping` | Make sure it's `resources:\n  cpu: …` not `resources: 500m`. |
+| `unknown baseImage 'forge'` | Use one of the supported base images above. |
+
+## Editor support
+
+There's no JSON Schema for `grounds.yaml` yet. On the roadmap; for now use this page as the reference. The Gradle plugin's parse error messages name the offending field and line number.

--- a/build/observability.mdx
+++ b/build/observability.mdx
@@ -1,0 +1,111 @@
+---
+title: "Observability"
+description: "Where to look when something is wrong — logs, metrics, traces."
+---
+
+Every workload pushed to the platform is wired into our LGTM stack:
+
+- **Loki** — logs from build steps and running pods.
+- **Mimir** — Prometheus metrics from base images and platform components.
+- **Tempo** — distributed traces (where instrumentation exists).
+- **Grafana** — the dashboarding + exploration front-end.
+
+Sign in with Grounds SSO at [grafana.platform.grnds.io](https://grafana.platform.grnds.io). Your project membership translates to which logs/metrics you can see.
+
+## Logs
+
+There are two distinct streams.
+
+### Build logs
+
+The build pipeline (Kaniko + push to in-cluster registry). Useful for diagnosing `build_failed`.
+
+```bash
+grounds logs <pushId>
+```
+
+In Grafana: **Explore** → Loki → query `{namespace="grounds-forge", app="kaniko"} |= "<pushId>"`.
+
+### Deployment logs
+
+The actual stdout/stderr of your running pod. Useful for everything else.
+
+```bash
+grounds logs deployment <name>           # tail until terminal/Ctrl-C
+grounds logs deployment <name> --no-follow
+```
+
+In the portal: **Deployments** → click into your app → **Logs** tab.
+
+In Grafana: filter by your namespace.
+
+```logql
+{namespace="user-<your-handle>", app="<name>"}
+```
+
+For staging previews: namespace is `preview-<id>`.
+
+## Metrics
+
+Standard JVM + base-image metrics are exposed automatically:
+
+- JVM heap / GC / thread pool (via `-javaagent` in the base image).
+- HTTP request rates and latencies for `service`-type workloads with our standard middleware.
+- Paper-specific tick rates for `plugin-paper`.
+
+Find them in Grafana under the **Workloads** folder. The default dashboard for your app is at:
+
+```
+https://grafana.platform.grnds.io/d/workload-overview?var-namespace=user-<handle>&var-app=<name>
+```
+
+The portal's deployment detail page links directly to this.
+
+### Custom metrics
+
+If your plugin or service exposes a `/metrics` endpoint (Prometheus format), add a `ServiceMonitor` to scrape it. We don't auto-discover arbitrary endpoints — explicit ServiceMonitors keep the cardinality budget under control.
+
+Examples and the `gnds_*` metric naming convention live in `tools/observability` (coming soon).
+
+## Traces
+
+If your code emits OTLP traces, they're forwarded to Tempo via an Alloy collector that runs as a sidecar in `service`-type pods. Traces are tied back to logs via the standard `trace_id` field — Grafana auto-links between them.
+
+Tracing for `plugin-paper` / `gamemode` workloads is opt-in (we don't auto-instrument the Bukkit / Minestom event bus by default). Reach out in `#grounds-platform` if you want this for your plugin.
+
+## Alerts
+
+Alert routing is platform-managed:
+
+- **Platform-level alerts** (cluster, ingress, base-image health) page the platform team.
+- **Project-level alerts** can be defined per-project in Grafana. The default is none — you opt in by writing rules.
+
+There's no SMS / phone integration. Alert destinations are Slack channels per project, configured by an owner.
+
+## Common queries
+
+| What | Where |
+|---|---|
+| "Why did my push fail?" | `grounds logs <pushId>` |
+| "Why is my pod crashlooping?" | `grounds logs deployment <name>` |
+| "Is the platform itself broken?" | [status.grounds.gg](https://status.grounds.gg) |
+| "What's the platform-level latency right now?" | Grafana → Platform → Latency dashboard |
+| "Did anyone push to this project today?" | Portal → project → Pushes |
+
+## Dashboards as code
+
+Project-specific Grafana dashboards can be checked in alongside your code:
+
+```yaml my-app-dashboard.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-app-dashboard
+  labels:
+    grafana_dashboard: "1"
+data:
+  dashboard.json: |-
+    { … }
+```
+
+Apply it to your app's namespace and the Grafana sidecar will pick it up. JSON dashboard exports from the Grafana UI work as a starting point.

--- a/build/portal.mdx
+++ b/build/portal.mdx
@@ -1,0 +1,82 @@
+---
+title: "Portal"
+description: "The web UI at portal.platform.grnds.io — projects, members, pushes, previews."
+---
+
+The portal is the visual side of the platform. Sign in with Grounds SSO at [portal.platform.grnds.io](https://portal.platform.grnds.io); membership in any project lands you on a project switcher.
+
+The CLI and the portal share the same forge backend — every operation in one is visible in the other.
+
+## What's where
+
+### Project switcher
+
+Top-left dropdown. Switch active project; affects every page below it. The selected project is remembered in your browser's local storage.
+
+### Pushes
+
+The history list for the current project: status badge, name, type, target, image tag, creation time. Click a row to open the push detail page with the full build + deploy log stream (SSE-tailed if still running, replayed if completed).
+
+Empty state explains how to make your first push if you haven't yet.
+
+### Previews
+
+Active preview environments for the current project. Per-row dropdown menu has:
+
+- **Pin (skip auto-cleanup)** — sets `pinned=true`, env survives past TTL.
+- **Unpin (re-enable cleanup)** — sets `pinned=false`, TTL recomputed from now.
+
+Status badges reflect the underlying push: `ready`, `pending`, `building`, `deploy_failed`, etc. The hostname is a clickable external link when status is `ready`.
+
+### Deployments
+
+The active deployments view (one row per running app, irrespective of which push placed it there). Click into one for live logs. This is the right surface to use when something is **currently broken** — the latest push might have succeeded but the pod is now crashlooping.
+
+### Members
+
+Project members with roles. Owners can:
+
+- **Add member** by handle (works only for already-signed-up users).
+- **Invite link** — generate a single-use URL, pick role + expiry.
+- Per-row: change role (owner/editor/viewer), remove member.
+- Self-removal (Leave project) is allowed for any member; forge enforces last-owner protection.
+
+### Settings
+
+- **Project info** — name, slug.
+- **Service accounts** — list, mint, revoke project-scoped API tokens. See [CI tokens](/build/ci-tokens).
+- **Audit** — recent member, token, and admin events.
+- **Danger zone** — archive / delete the project.
+
+### Account
+
+Top-right avatar:
+
+- Linked identity (your Grounds SSO email + handle).
+- Theme toggle: System / Light / Dark.
+- Sign out.
+
+## Theme
+
+The portal supports system, light, and dark themes via the `data-mode` attribute on `<html>`. Your choice is persisted per browser. The CLI is unaffected (it uses your terminal's theme).
+
+## Keyboard shortcuts
+
+| Key | Action |
+|---|---|
+| `g p` | Go to Pushes |
+| `g v` | Go to Previews |
+| `g m` | Go to Members |
+| `?` | Show shortcuts |
+
+Type into an input and shortcuts are suppressed.
+
+## What it can't do (yet)
+
+The portal is feature-complete for **observation** and **member/token management**. Things still CLI-only:
+
+- Initiating a push (you upload a JAR, which a browser file picker won't carry well across CI etc.).
+- Promoting a push to production.
+- Bulk operations on pushes or previews.
+
+Most "make changes" workflows go through the CLI; the portal is the read + administer surface.

--- a/build/quickstart.mdx
+++ b/build/quickstart.mdx
@@ -1,0 +1,142 @@
+---
+title: "Quickstart"
+description: "From zero to a public Minecraft server URL in five minutes."
+---
+
+This guide walks through your first push. By the end you'll have a Paper plugin running on managed infrastructure, reachable at a public `*.mc.grnds.io` address.
+
+## Prerequisites
+
+- A Grounds SSO account (talk to your org admin if you don't have one yet)
+- Java 21+ and Gradle (a Gradle wrapper in your project is fine)
+- macOS, Linux, or Windows (WSL2 works)
+
+## Install the CLI
+
+<Tabs>
+<Tab title="macOS / Linux (Homebrew)">
+```bash
+brew install groundsgg/tap/grounds
+grounds version
+```
+</Tab>
+
+<Tab title="Linux (curl)">
+```bash
+curl -fsSL https://raw.githubusercontent.com/groundsgg/grounds-cli/main/install.sh | sh
+```
+</Tab>
+
+<Tab title="Windows (Scoop)">
+```powershell
+scoop bucket add grounds https://github.com/groundsgg/scoop-bucket
+scoop install grounds
+```
+</Tab>
+</Tabs>
+
+## Sign in
+
+```bash
+grounds login
+```
+
+The CLI opens your browser to Grounds SSO. Approve the device code shown in the terminal — the CLI persists tokens in your OS keyring and you only need to repeat this when the session expires (usually weekly).
+
+Verify with:
+
+```bash
+grounds doctor
+```
+
+You should see green checks on `auth`, `api`, and `gradle wrapper` (if run from a project root).
+
+## Set up the Gradle plugin
+
+Grounds builds straight from Gradle. Add the plugin to your `build.gradle.kts`:
+
+```kotlin
+plugins {
+    `java-library`
+    id("gg.grounds.push") version "0.x" // see Releases for current
+}
+
+groundsPush {
+    // Reads ~/.config/grounds/credentials.json by default; no extra config needed.
+}
+
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
+}
+```
+
+Then create a `grounds.yaml` next to `build.gradle.kts`:
+
+```yaml
+name: my-plugin
+type: plugin-paper
+baseImage: paper
+jar: build/libs/my-plugin-0.1.0.jar
+```
+
+<Note>
+The `baseImage` field selects the runtime: `paper`, `velocity`, `minestom`, or `service`. Each maps to a vetted image we keep up to date.
+</Note>
+
+## Your first push
+
+```bash
+grounds push --target=dev
+```
+
+What happens:
+
+1. The Gradle plugin assembles your JAR and uploads it + the manifest to the Grounds API.
+2. **Forge** runs a Kaniko build inside the cluster, pushes the resulting OCI image to the internal registry, and signs it with cosign.
+3. Forge applies a Deployment + Service to your personal namespace (`user-<your-handle>`).
+4. Once the pod is Ready, the CLI prints the public URL.
+
+Output looks like:
+
+```
+✔ Build complete (image sha256:abc…)
+✔ Deploy ready
+  → minecraft://my-plugin-yourname.mc.grnds.io
+```
+
+Connect from any Minecraft client using that address. The first connection cold-starts the server (~15s); after that it stays warm until idle.
+
+## Ephemeral preview env
+
+For sharing a build with playtesters without polluting your dev environment:
+
+```bash
+grounds push --target=staging
+```
+
+This creates a fresh `preview-<id>` namespace with a 7-day TTL. Hostname pattern: `<name>-pr<id>.mc.grnds.io`. Grounds garbage-collects the env automatically once the TTL expires — pin it to keep it longer:
+
+```bash
+grounds preview list           # find the id
+grounds preview pin <id>       # opt out of auto-cleanup
+```
+
+## Next steps
+
+<CardGroup cols={2}>
+<Card title="CLI reference" icon="terminal" href="/build/cli">
+  Every subcommand and flag.
+</Card>
+
+<Card title="Concepts" icon="book" href="/build/concepts">
+  Projects, dev clusters, preview envs — what they are and how they relate.
+</Card>
+
+<Card title="Troubleshooting" icon="bug" href="/build/troubleshooting">
+  Common errors and how to fix them.
+</Card>
+
+<Card title="API reference" icon="code" href="/apis">
+  Forge HTTP API for custom integrations.
+</Card>
+</CardGroup>

--- a/build/quickstart.mdx
+++ b/build/quickstart.mdx
@@ -136,7 +136,7 @@ grounds preview pin <id>       # opt out of auto-cleanup
   Common errors and how to fix them.
 </Card>
 
-<Card title="API reference" icon="code" href="/apis">
+<Card title="API reference" icon="code" href="/reference/apis">
   Forge HTTP API for custom integrations.
 </Card>
 </CardGroup>

--- a/build/test-environment/bundle-reference.mdx
+++ b/build/test-environment/bundle-reference.mdx
@@ -1,0 +1,326 @@
+---
+title: "Bundle Reference"
+description: "Field-by-field reference for bundle.yaml and the Engineer-Override-File schema"
+---
+
+Use this when adding a new component to a bundle, debugging an unexpected resolved value, or building tooling that consumes the bundle.
+
+A **bundle** is a versioned, curated list of platform components and the default versions of each. Engineers pin against a bundle release for reproducible runs (CI), or against the moving edge for daily iteration. Forge resolves a bundle plus an optional override file into a concrete set of Helm releases, then applies them inside your per-engineer vCluster.
+
+## Top-level shape
+
+```yaml
+apiVersion: platform.grnds.io/v1
+kind: PlatformBundle
+metadata:
+  version: 0.4.0
+  description: |
+    Free-form description...
+shared:
+  nats: { ... }
+  postgres: { ... }
+  keycloak: { ... }
+components:
+  velocity: { ... }
+  plugin-social: { ... }
+  ...
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `apiVersion` | string | yes | Must equal `platform.grnds.io/v1`. Forge rejects other values. |
+| `kind` | string | yes | Must equal `PlatformBundle`. |
+| `metadata.version` | semver | yes | Source-of-truth for the bundle's own version. release-please bumps this in lockstep with the git tag. |
+| `metadata.description` | string | no | Human-readable. |
+| `shared` | object | yes | Tailnet-exposed backends shared across all engineer vClusters. |
+| `components` | map | yes | Map of release-name → BundleComponent. |
+
+## `shared`
+
+Backends that **don't** run inside an engineer's vCluster. Each in-vCluster service connects out via Tailscale to these endpoints.
+
+<Warning>
+The endpoints declared here are only reachable from the **internal Grounds tailnet** — a private Tailscale network for authorized engineers. External contributors won't be able to resolve `nats.dev` / `postgres.dev` / `keycloak.dev`. The bundle composition is still publicly readable; only the runtime is gated.
+</Warning>
+
+```yaml
+shared:
+  nats:
+    tailnet: nats.dev
+    port: 4222
+    description: NATS JetStream — cross-service events and the KV store for player presence
+  postgres:
+    tailnet: postgres.dev
+    port: 5432
+    description: One database per engineer (`<handle>_<service>`); shared server
+  keycloak:
+    tailnet: keycloak.dev
+    port: 443
+    realm: grounds-test
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `<endpoint>.tailnet` | string | yes | MagicDNS hostname on the internal Grounds tailnet. The engineer must be on the tailnet and have the matching dev-routes ACL enabled. |
+| `<endpoint>.port` | int | yes | TCP port at the endpoint. |
+| `<endpoint>.description` | string | no | Human-readable. |
+| `keycloak.realm` | string | yes for keycloak | Realm name. Currently `grounds-test`. |
+
+<Note>
+The shared block is informational — forge doesn't push these values into helm values automatically. The component charts are responsible for connecting using the same names (e.g. the in-vCluster `service-config` chart has `NATS_URL=nats://nats.dev:4222` baked into its env).
+</Note>
+
+## `components`
+
+A map: each key is the **Helm release name** (also used as namespace-DNS-label inside the vCluster, so it must be a valid DNS-1123 label — lowercase, hyphens, no underscores). Each value is a `BundleComponent`:
+
+```yaml
+components:
+  plugin-social:
+    type: plugin-velocity
+    chart:
+      url: oci://ghcr.io/groundsgg/charts/plugin-velocity-jar
+      version: 0.1.0
+    image: ghcr.io/groundsgg/plugin-social
+    version: edge
+    optional: false
+    helm:
+      resources:
+        requests: { cpu: 50m, memory: 64Mi }
+    devspace:
+      workflow: jar-sync-pod-restart
+```
+
+### `BundleComponent` fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `type` | string | yes | Component-type string. See below. |
+| `chart.url` | string | yes | OCI Helm chart URL. |
+| `chart.version` | semver | yes | Pinned Helm chart version. |
+| `image` | string | yes | Container image without tag. Forge passes this as `image.repository` into helm values. |
+| `version` | string | yes | Image tag — semver, `edge`, or any other ref. Passed as `image.tag`. |
+| `optional` | bool | no, default `false` | When `true`, the component is **not deployed by default**. Override with `enabled: true` to bring it in. |
+| `helm` | map | no | Free-form Helm values. See merging rules below. |
+| `devspace.workflow` | string | no | Selects a DevSpace template when the component is overridden into `gradle-local` mode. |
+
+### Component types
+
+The `type` field is a string for forward-compat, but the platform-test environment understands these values:
+
+| Type | What it is | DevSpace workflow | Iter-Latency |
+|---|---|---|---|
+| `plugin-velocity-base` | The Velocity proxy itself | `jar-sync-pod-restart` | ~10–20 s |
+| `plugin-velocity` | A JAR plugin loaded by Velocity at startup | `jar-sync-pod-restart` | ~10–20 s |
+| `plugin-paper` *(planned)* | A JAR plugin loaded by Paper | `jar-sync-plugin-reload` | ~5–15 s |
+| `gamemode` | Minestom or Paper game-server | `jar-sync-pod-restart` | ~10–20 s |
+| `grpc-service` | Quarkus-based gRPC backend | `quarkus-dev` | ~1–3 s |
+| `utility` | Test/debug tooling (e.g. nats-recorder) | – | – |
+
+Forge uses `type` only for default-behavior decisions (today: which DevSpace workflow template to suggest). Adding a new type is a bundle PR, not a forge PR.
+
+### Helm value merging
+
+The values forge passes to `helm install` for a component are produced by:
+
+<Steps>
+<Step title="Start with the component's helm: block">
+Or `{}` if absent.
+</Step>
+<Step title="Inject image.repository + image.tag">
+Deep-merge `{ image: { repository: <component.image>, tag: <resolved-tag> } }` on top.
+</Step>
+<Step title="Inject DevSpace pickup annotations (when gradle-local)">
+Deep-merge a `podAnnotations` block:
+
+```yaml
+podAnnotations:
+  grounds.gg/devspace-mode: gradle-local
+  grounds.gg/devspace-project: ./plugin-social
+  grounds.gg/devspace-artifact: build/libs/*-all.jar
+  grounds.gg/devspace-reload: pod-restart
+  grounds.gg/devspace-quarkus-dev: "true"   # only when devspace:true
+```
+</Step>
+</Steps>
+
+Deep-merge rules:
+
+- Plain-object values are merged recursively.
+- Arrays are replaced wholesale (no list-merge).
+- Primitives are replaced.
+
+<Warning>
+`helm.image.tag = "0.5.0"` in the bundle is **not** a useful value — forge will overwrite it with the resolved tag. Pin via the `version:` field instead.
+</Warning>
+
+## Override-File schema
+
+Engineers write an override YAML and pass it to `grounds cluster up --bundle X --override ./me.yaml`. Schema:
+
+```yaml
+bundle: 0.4.0    # bundle ref to apply against. --bundle on cmd-line wins.
+
+overrides:
+  <component-name>: <ComponentOverride>
+```
+
+`<ComponentOverride>` is a discriminated union — exactly **one** of these shapes:
+
+<Tabs>
+<Tab title="image (default)">
+
+Use the bundle's image but optionally override the tag.
+
+```yaml
+overrides:
+  velocity:
+    mode: image
+    tag: dev-fix-routing-123    # optional
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `mode` | `"image"` | yes | |
+| `tag` | string | no | Replaces the bundle's `version:` for this component. Omit to keep the default. |
+
+</Tab>
+<Tab title="gradle-local">
+
+Engineer's local gradle project supplies the JAR (or runs Quarkus dev). Forge stamps DevSpace pickup annotations onto the deployed Pod so DevSpace can find the right Pod.
+
+```yaml
+overrides:
+  plugin-social:
+    mode: gradle-local
+    project: ./plugin-social
+    artifact: build/libs/plugin-social-*.jar
+    reload: pod-restart
+```
+
+```yaml
+overrides:
+  service-social:
+    mode: gradle-local
+    project: ./service-social
+    devspace: true   # → quarkus-dev workflow
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `mode` | `"gradle-local"` | yes | |
+| `project` | string | yes | Workspace-relative path. Used by DevSpace, not by forge directly. |
+| `artifact` | string | yes (non-`devspace`) | Glob for the built JAR. Required by `jar-sync-pod-restart`. |
+| `reload` | `"rcon-plugin-reload"` \| `"pod-restart"` | no | How DevSpace re-applies the new JAR. Default `pod-restart`. |
+| `devspace` | bool | no | When `true`, switch to the `quarkus-dev` workflow (sub-second hot-reload). |
+
+</Tab>
+<Tab title="enabled: false">
+
+Skip the component entirely.
+
+```yaml
+overrides:
+  paper-game:
+    enabled: false
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `enabled` | `false` | yes | The literal `false`. |
+
+There's intentionally no `enabled: true` form for non-optional components — they're already on. For components with `optional: true` in the bundle (e.g. `nats-recorder`), `enabled: true` flips them on:
+
+```yaml
+overrides:
+  nats-recorder:
+    enabled: true
+```
+
+</Tab>
+</Tabs>
+
+## Pod annotations
+
+The fields `project`, `artifact`, `reload`, and `devspace` aren't applied by forge — they're echoed as Pod annotations for DevSpace to read on the engineer's laptop. The annotations forge writes:
+
+| Annotation | Value |
+|---|---|
+| `grounds.gg/devspace-mode` | `gradle-local` |
+| `grounds.gg/devspace-project` | the `project` value |
+| `grounds.gg/devspace-artifact` | the `artifact` value |
+| `grounds.gg/devspace-reload` | the `reload` value (only when set) |
+| `grounds.gg/devspace-quarkus-dev` | `"true"` when `devspace: true` |
+
+## Resolution algorithm
+
+When forge gets `(bundle, override-file)`:
+
+<Steps>
+<Step title="Filter components">
+Drop everything where `override.enabled === false`. Drop `optional: true` components that aren't explicitly enabled.
+</Step>
+<Step title="Resolve per remaining component">
+- If override is `mode: image` with `tag`: replace `imageTag` with the override.
+- If override is `mode: gradle-local`: keep image+tag from bundle; mark mode for annotation injection later.
+- If no override: use bundle defaults.
+</Step>
+<Step title="Compute helm values">
+Deep-merge per the rules above.
+</Step>
+<Step title="Helm install">
+Best-effort, parallel-friendly. If one component's chart is missing, the others still go through. Failed components are reported in the response body but don't fail the call.
+</Step>
+</Steps>
+
+## Adding a new component
+
+<Steps>
+<Step title="Ensure the chart exists">
+Make sure the component-type's Helm chart is in `groundsgg/charts` and published as an OCI artifact (or co-publish it in the same PR).
+</Step>
+<Step title="Add a components: entry to bundle.yaml">
+
+```yaml
+plugin-foo:
+  type: plugin-velocity            # or whichever type
+  chart:
+    url: oci://ghcr.io/groundsgg/charts/plugin-velocity-jar
+    version: 0.1.0
+  image: ghcr.io/groundsgg/plugin-foo
+  version: edge
+  devspace:
+    workflow: jar-sync-pod-restart
+```
+
+</Step>
+<Step title="Mark optional if it shouldn't run by default">
+Add `optional: true` and document the opt-in in `examples/`.
+</Step>
+<Step title="Open the PR">
+release-please bumps the bundle version on merge.
+</Step>
+</Steps>
+
+## Versioning
+
+[release-please](https://github.com/googleapis/release-please) drives the bundle version:
+
+| Commit type | Bump |
+|---|---|
+| `feat:` | minor |
+| `fix:` | patch |
+| `feat!:` / `BREAKING CHANGE:` | major |
+
+Engineers pin against bundle versions:
+
+```yaml
+bundle: 0.4.0     # reproducible
+```
+
+`bundle: main` always tracks the latest commit on `main` — useful for daily iteration, not for CI.
+
+## See also
+
+- [Test Environment overview](/build/test-environment) — engineer onboarding from `grounds login` to a hot-reload loop
+- [`groundsgg/charts`](https://github.com/groundsgg/charts) — the Helm charts each component type maps to

--- a/build/test-environment/index.mdx
+++ b/build/test-environment/index.mdx
@@ -1,0 +1,288 @@
+---
+title: "Platform Test Environment"
+description: "Per-engineer copies of the Grounds platform stack — for iterating on plugins, gamemodes, or services in isolation"
+---
+
+The platform test environment gives every engineer their own vCluster with the full Grounds stack — Velocity proxy, plugins, lobby, gamemodes, gRPC services — running against shared backends (NATS, Postgres, Keycloak) over the service-tailnet.
+
+You override only the components you're actively working on, leave everything else on the bundle's defaults, and iterate with DevSpace's hot-reload loop.
+
+<Warning>
+This environment is **for authorized Grounds engineers only**. It relies on a private Tailscale network to reach shared backend services (NATS, Postgres, Keycloak); without an invite to the Grounds tailnet you can't follow this guide end-to-end. If you're an external contributor working on a public component, look at the public CI flow instead.
+</Warning>
+
+<Note>
+A **bundle** is a versioned, curated list of platform components and their default versions. You pin against a bundle release (for reproducible CI runs) or against the current edge (for daily iteration). The full schema is documented under [Bundle Reference](/build/test-environment/bundle-reference).
+</Note>
+
+## TL;DR
+
+```bash
+grounds login
+grounds cluster up --bundle 0.4.0
+# → spins up your vCluster + deploys the full bundle stack
+
+cp library-platform-bundle/devspace/jar-sync-pod-restart.devspace.yaml plugin-social/devspace.yaml
+cd plugin-social
+devspace dev plugin-social
+```
+
+## 1. Prerequisites
+
+| Tool | Why | Install |
+|---|---|---|
+| **Tailscale** | NATS / Postgres / Keycloak are exposed only over the **internal Grounds tailnet** (authorized engineers only) | `tailscale up`, accept `nats.dev` / `postgres.dev` / `keycloak.dev` MagicDNS routes after you've been added to the tailnet |
+| **kubectl** | Hand-debug pods inside your vCluster | `brew install kubectl` |
+| **helm** | Occasional raw helm + DevSpace templates do `kubectl rollout restart` | `brew install helm` |
+| **devspace** | The hot-iteration loop | `brew install devspace` |
+| **gradle + JDK 25** | Building plugin / service JARs locally | `brew install gradle openjdk@25` |
+| **grounds-cli** | Control plane for your workspace | See [CLI installation](/build/cli/installation) |
+
+Sanity check:
+
+```bash
+grounds doctor
+```
+
+It validates auth, API reachability, and Tailscale routes for `*.dev`.
+
+## 2. Bootstrap your vCluster
+
+```bash
+grounds login                       # OAuth device flow against account.grounds.gg
+grounds cluster up --bundle 0.4.0
+```
+
+What this does:
+
+<Steps>
+<Step title="Resolve project">
+Forge resolves your default project on the platform side.
+</Step>
+<Step title="Ensure host namespace">
+A per-engineer host namespace `vcluster-<handle>` (privileged PSA) is created if missing.
+</Step>
+<Step title="Install vCluster">
+`helm install` of `loft/vcluster`, idempotent — re-runs are no-ops if the vCluster already exists.
+</Step>
+<Step title="Wait for vCluster API">
+The reconciler polls until the inner API is up and pulls its kubeconfig out of a Secret.
+</Step>
+<Step title="Resolve bundle">
+The forge service fetches `bundle.yaml @ 0.4.0` and merges it with your override file (if any) into a concrete component list.
+</Step>
+<Step title="Deploy components">
+Each component is `helm install`'d into the vCluster, best-effort — a chart-not-found on one component doesn't abort the rest.
+</Step>
+</Steps>
+
+The output tells you which components landed and which ones errored:
+
+```
+✔ active — bundle 0.4.0 — vcluster-lusu
+  components: 15 resolved, 14 succeeded, 1 failed
+  failed:
+    - paper-game: chart oci://ghcr.io/groundsgg/charts/grounds-gamemode:0.1.0 not found
+```
+
+Re-run `grounds cluster up --bundle 0.4.0` after fixing the cause and the reconciler picks up where it left off.
+
+<Tip>
+**Bundle pin vs. `main`** — `--bundle 0.4.0` is reproducible: that exact composition gives you the same component versions every time. `--bundle main` always tracks the moving edge. Pin in CI, float locally.
+</Tip>
+
+## 3. Get your vCluster's kubeconfig
+
+For raw `kubectl` / `helm` / `devspace` access to the inner cluster, the kubeconfig lives in a Secret on the host namespace:
+
+```bash
+HANDLE=$(whoami)
+kubectl --context=platform-cluster -n vcluster-$HANDLE \
+  get secret vcluster-$HANDLE -o jsonpath='{.data.config}' \
+  | base64 -d > ~/.kube/config-vcluster-$HANDLE
+export KUBECONFIG=~/.kube/config-vcluster-$HANDLE
+kubectl get pods -n default
+```
+
+Each engineer's vCluster runs separately on the platform cluster — your `default` namespace **inside the vCluster** is your stack.
+
+<Note>
+A first-class `grounds cluster kubeconfig` subcommand is planned but not yet shipped — for now the manual fetch above is the supported path.
+</Note>
+
+## 4. Override a component
+
+Without overrides, every component runs the released image at the version pinned by the bundle. To swap one for your local code, write an override file:
+
+```yaml overrides/me.yaml
+bundle: 0.4.0
+
+overrides:
+
+  # Build plugin-social locally, sync the JAR into the running pod.
+  plugin-social:
+    mode: gradle-local
+    project: ./plugin-social
+    artifact: build/libs/plugin-social-*.jar
+    reload: pod-restart       # rolls Velocity so it picks the new JAR
+
+  # Run service-config in Quarkus dev mode (sub-second hot-reload).
+  service-social:
+    mode: gradle-local
+    project: ./service-social
+    devspace: true            # → quarkus-dev workflow
+
+  # Engineer wants a specific velocity tag, not the bundle default.
+  velocity:
+    mode: image
+    tag: dev-fix-routing-123
+
+  # Skip paper-game entirely in this stack.
+  paper-game:
+    enabled: false
+
+  # Turn on optional test tooling.
+  nats-recorder:
+    enabled: true
+```
+
+Apply it:
+
+```bash
+grounds cluster up --bundle 0.4.0 --override ./overrides/me.yaml
+```
+
+### Override schema
+
+| Mode | When | Required fields |
+|---|---|---|
+| `image` (default) | Run the bundle's default image | – |
+| `image` + `tag: <X>` | Same image, different tag | `tag` |
+| `gradle-local` | Local JAR sync | `project`, `artifact`, `reload` |
+| `gradle-local` + `devspace: true` | Quarkus dev mode | `project` |
+| `enabled: false` | Skip the component | – |
+| `enabled: true` | Turn on a default-off optional component | – |
+
+See [Bundle Reference](/build/test-environment/bundle-reference) for the full override schema and field-level documentation.
+
+## 5. Iterate on a component
+
+The bundle's per-component `devspace.workflow` field selects which template applies:
+
+| Component-Type | DevSpace Workflow | Iter-Latency |
+|---|---|---|
+| `plugin-velocity` | `jar-sync-pod-restart` (Velocity has no in-process hot-reload, so the pod is restarted) | ~10–20 s |
+| `gamemode` (Minestom/Paper) | `jar-sync-pod-restart` | ~10–20 s |
+| `grpc-service` (Quarkus) | `quarkus-dev` (Live-Reload sub-second) | ~1–3 s |
+
+<Tabs>
+<Tab title="Plugin / lobby / gamemode">
+
+Use `jar-sync-pod-restart`:
+
+```bash
+cp library-platform-bundle/devspace/jar-sync-pod-restart.devspace.yaml plugin-social/devspace.yaml
+cd plugin-social
+devspace dev plugin-social \
+  --var COMPONENT_NAME=plugin-social \
+  --var PROJECT_DIR=. \
+  --var JAR_GLOB="build/libs/*-all.jar" \
+  --var RESTART_TARGET=velocity
+```
+
+DevSpace will:
+
+1. Run `./gradlew build` locally.
+2. Sync the produced JAR into the plugin pod's `/shared/plugin.jar`.
+3. `kubectl rollout restart deployment/velocity` — Velocity's init-containers re-fetch your JAR.
+4. Watch `build/libs/` and re-do all of the above on every change.
+
+</Tab>
+<Tab title="gRPC service">
+
+Use `quarkus-dev`:
+
+```bash
+cp library-platform-bundle/devspace/quarkus-dev.devspace.yaml service-social/devspace.yaml
+cd service-social
+devspace dev service-social \
+  --var COMPONENT_NAME=service-social \
+  --var PROJECT_DIR=. \
+  --var GRPC_PORT=9000 \
+  --var HTTP_PORT=8080
+```
+
+DevSpace will:
+
+1. Replace the deployed image with the Quarkus dev shim (`ghcr.io/groundsgg/quarkus-dev-base:25`).
+2. Sync your source tree into `/workspace` in the pod.
+3. Run `./gradlew quarkusDev` inside the pod.
+4. Port-forward `localhost:9000` (gRPC) and `localhost:8080` (HTTP / dev-UI) to the pod.
+
+Edit a `.kt` file → Quarkus reloads in ~1s. Dev-UI at [http://localhost:8080/q/dev](http://localhost:8080/q/dev).
+
+</Tab>
+</Tabs>
+
+## 6. Inspect the event bus
+
+The bundle has an opt-in `nats-recorder` component that subscribes to chosen subjects and emits each message as JSONL on stdout — useful for debugging cross-service events without writing one-off subscribers.
+
+```yaml
+# overrides/me.yaml
+overrides:
+  nats-recorder:
+    enabled: true
+```
+
+After `grounds cluster up`, tail it:
+
+```bash
+kubectl logs -f deployment/nats-recorder | jq .
+```
+
+Subjects it listens on are configured in `bundle.yaml` (default: `config.>`, `player.>`, `friends.>`, `match.>`).
+
+## 7. Tear down
+
+```bash
+grounds cluster down            # pause; resume with `cluster up`
+grounds cluster delete          # drop the vCluster + namespace entirely
+```
+
+`down` is cheap to reverse; `delete` requires re-running the bundle deploys from scratch. To swap one component out without losing state, use overrides — don't delete.
+
+## 8. Troubleshooting
+
+<AccordionGroup>
+<Accordion title="forge says &quot;chart not found&quot; for a component">
+The Helm chart for that component type isn't published yet. The forge response's `failed[]` block tells you exactly which component and which chart URL failed. Either wait for the chart to be released or override the failing component with `enabled: false` so the rest of the stack still comes up.
+</Accordion>
+
+<Accordion title="Pod stuck in Init waiting for fetch-<plugin>">
+The `grounds-velocity` chart's init-containers `curl` each plugin's Service at `http://<plugin>:8080/plugin.jar`. If a plugin pod isn't ready (e.g. its image doesn't exist or it's still pulling), the velocity pod waits. `kubectl get pods` and look for the plugin pods that aren't `Running`.
+</Accordion>
+
+<Accordion title="DevSpace sync writes the JAR but Velocity doesn't pick it up">
+The `jar-sync-pod-restart` workflow assumes you set `RESTART_TARGET=velocity` for plugin-* components. Without the rollout-restart, Velocity keeps the old JAR loaded. Check the `onUpload.execRemote` block in your `devspace.yaml`.
+</Accordion>
+
+<Accordion title="Tailscale can't resolve nats.dev / postgres.dev">
+You're not on the internal Grounds tailnet. This is a private network for authorized engineers — if you haven't been invited yet, ask a maintainer. Once you're on, run `tailscale status` to confirm the routes; if they're missing, re-run `tailscale up` accepting the dev-routes ACL.
+</Accordion>
+
+<Accordion title="409 'cannot apply bundle to platform workspace'">
+You already have a `profile=platform` workspace from the older flow. The bundle workflow uses `profile=platform-bundle` and they're not interchangeable. `grounds cluster delete` first, then re-up with `--bundle`.
+</Accordion>
+
+<Accordion title="A component's helm-install errors after a successful first deploy">
+`grounds cluster up --bundle X` is idempotent and uses `helm install/upgrade`. If a chart's values shape changed between bundle versions, a stale release can block the upgrade. Drop the specific component's release inside the vCluster (`helm uninstall <component>` against the vCluster kubeconfig) and re-run `cluster up`.
+</Accordion>
+</AccordionGroup>
+
+## 9. Reference
+
+- [Bundle Reference](/build/test-environment/bundle-reference) — every field of `bundle.yaml` and the override-file schema
+- [`grounds-cli`](https://github.com/groundsgg/grounds-cli) — CLI source + releases
+- [`groundsgg/charts`](https://github.com/groundsgg/charts) — public Helm charts referenced by bundles
+- [`groundsgg/library-grpc-contracts`](https://github.com/groundsgg/library-grpc-contracts) — shared protobuf event schemas

--- a/build/troubleshooting.mdx
+++ b/build/troubleshooting.mdx
@@ -1,0 +1,166 @@
+---
+title: "Troubleshooting"
+description: "Symptoms you'll hit, and what to check first."
+---
+
+## CLI
+
+### `not logged in`
+
+```
+✗ auth   not logged in
+```
+
+Run `grounds login`. The CLI didn't find a `credentials.json` (or `GROUNDS_TOKEN`).
+
+### `session expired`
+
+```
+✗ auth   session expired (run 'grounds login')
+```
+
+Your refresh token has aged out (≈30 days of inactivity). Run `grounds login` to start fresh.
+
+### `api  Get "https://platform.grnds.io/healthz": …`
+
+The CLI can't reach forge. Check:
+
+- Network connectivity (can you `curl https://platform.grnds.io/healthz`?).
+- Are you on a VPN that blocks the domain? Try with VPN off.
+- Did you set `--api-url` or `GROUNDS_API_URL` to a typo? Unset it.
+- [status.grounds.gg](https://status.grounds.gg) for ongoing platform issues.
+
+### `gradle wrapper not found`
+
+```
+✗ not a Gradle project? Run 'grounds init' to scaffold, or cd to your project root
+```
+
+You're running `grounds push` outside a Gradle project. `cd` to the directory with `gradlew` / `build.gradle.kts`.
+
+## Manifest
+
+### `grounds.yaml: missing required field 'name'`
+
+Add the missing field. Required fields are `name`, `type`, `baseImage` — see [manifest reference](/build/manifest).
+
+### `grounds.yaml: 'resources' must be a mapping`
+
+You wrote `resources: 500m` instead of:
+
+```yaml
+resources:
+  cpu: 500m
+  memory: 1Gi
+```
+
+### `groundsTestLocal only supports baseImage=paper|velocity`
+
+Local mode only runs Paper and Velocity. Use `grounds push --target=dev` for `minestom` / `service` workloads.
+
+## Build (`build_failed`)
+
+### `kaniko: failed to push to registry`
+
+Transient registry hiccup. Retry:
+
+```bash
+grounds push retry <pushId>
+```
+
+If it persists, check `#grounds-platform` for a registry incident.
+
+### `kaniko: COPY failed: no source files were found`
+
+Your manifest's `jar:` glob doesn't match any file. Check:
+
+- `./gradlew shadowJar` produces something at `build/libs/`.
+- The glob in `grounds.yaml` (or auto-detected) matches it.
+- The Gradle plugin successfully built before upload (look at the build output).
+
+### Build hangs in `building` for >5 minutes
+
+The pipeline's hard timeout is 30 minutes per step; the CLI's SSE inactivity timeout is 5 minutes. If the latter triggers, the build is still running on the cluster — re-attach by tailing logs:
+
+```bash
+grounds logs <pushId>
+```
+
+If the build itself is genuinely stuck, that's a platform issue — ping `#grounds-platform`.
+
+## Deploy (`deploy_failed`)
+
+### `ImagePullBackOff`
+
+Most often: the build "succeeded" but the image isn't actually at the registry. Symptoms align with a registry that ran out of disk or the image push happened-after the deploy started.
+
+Retry: `grounds push retry <pushId>`. If it keeps failing, the registry needs platform attention.
+
+### `CrashLoopBackOff`
+
+Your pod is starting and immediately exiting. Look at the deployment logs:
+
+```bash
+grounds logs deployment <name>
+```
+
+Common causes:
+
+- Plugin throws on `onEnable` — fix the code, push again.
+- Java version mismatch (you compiled for 22, base image runs 21).
+- Missing dependency at runtime (you assumed a library would be present that isn't).
+
+### `OOMKilled`
+
+Pod exceeded its memory limit. Bump `resources.memory` in `grounds.yaml` (within project quota), or shrink your heap. Check Grafana for the JVM heap usage that led up to the OOM.
+
+### Quota exceeded at admission
+
+```
+push failed: project quota exceeded — 5/5 staging environments active
+```
+
+Either delete some old previews (or unpin them and wait for the janitor), or request a quota bump in `#grounds-platform`.
+
+## Preview environments
+
+### "My preview was working yesterday and now it's gone"
+
+Default TTL is 7 days. Check:
+
+```bash
+grounds preview list --include-deleted
+```
+
+If it's there with a `deleted` status, the janitor swept it. Push again or pin the new one.
+
+### Public URL returns 502
+
+The pod isn't `ready`. Tail deployment logs:
+
+```bash
+grounds logs deployment <name>
+```
+
+The hostname only routes to a `ready` pod — during a redeploy or crashloop you'll see 502 from the ingress.
+
+## Auth & SSO
+
+### `403 Forbidden` from forge on every call
+
+You're authenticated but not a member of the project the request targets. Check:
+
+- The project ID in `--project` / `GROUNDS_PROJECT` / `config.toml`.
+- Your role in the portal (Settings → Members).
+
+If you used a service-account token, it's hard-pinned to its minting project — you cannot use it elsewhere.
+
+### Browser opens to "invalid_redirect_uri"
+
+The CLI's redirect URI must match what's configured at Grounds SSO. If you self-host the IdP or the CLI binary is stale, this can drift. Re-install the CLI.
+
+## Where to ask for help
+
+1. **`#grounds-platform`** Slack channel — fastest path. Include push ID, manifest, and last 30 lines of logs.
+2. **GitHub issue** at [groundsgg/grounds-platform](https://github.com/groundsgg/grounds-platform) — for reproducible bugs.
+3. **status.grounds.gg** — to confirm whether it's a known incident before reporting.

--- a/docs.json
+++ b/docs.json
@@ -18,6 +18,54 @@
         ]
       },
       {
+        "tab": "Build",
+        "pages": [
+          "build/index",
+          "build/quickstart",
+          {
+            "group": "Concepts",
+            "pages": [
+              "build/concepts/projects-and-teams",
+              "build/concepts/targets",
+              "build/concepts/pushes",
+              "build/concepts/preview-environments"
+            ]
+          },
+          {
+            "group": "CLI",
+            "pages": [
+              "build/cli/installation",
+              "build/cli/auth",
+              "build/cli/push",
+              "build/cli/preview",
+              "build/cli/configuration"
+            ]
+          },
+          "build/manifest",
+          {
+            "group": "Gradle plugin",
+            "pages": [
+              "build/gradle-plugin/setup",
+              "build/gradle-plugin/groundsPush",
+              "build/gradle-plugin/groundsPushRetry",
+              "build/gradle-plugin/groundsTestLocal"
+            ]
+          },
+          "build/ci-tokens",
+          "build/portal",
+          "build/local-development",
+          "build/observability",
+          "build/troubleshooting",
+          {
+            "group": "Internal — Grounds engineers only",
+            "pages": [
+              "build/test-environment/index",
+              "build/test-environment/bundle-reference"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Deploy",
         "pages": [
           "deploy/index",

--- a/index.mdx
+++ b/index.mdx
@@ -10,6 +10,10 @@ Use this documentation to find the Grounds platform resources, supported integra
 Choose the section that matches what you want to do:
 
 <CardGroup cols={2}>
+<Card title="Build for Grounds" icon="rocket" href="/build">
+  Ship a Minecraft plugin or game mode to managed infrastructure — start here if you're a developer.
+</Card>
+
 <Card title="Deploy" icon="server" href="/deploy">
   Containers, Helm charts, and the Keycloak Minecraft identity provider — the building blocks for running the Grounds stack in your own Kubernetes cluster.
 </Card>


### PR DESCRIPTION
## Summary
- New top-level **Build** tab for external devs who want to ship Minecraft plugins/game modes to managed Grounds infra
- Two pages on first cut:
  - \`build/index\` — landing (who it's for, value prop, 5-min preview)
  - \`build/quickstart\` — full walkthrough (\`brew install\` → \`grounds login\` → first push, both \`target=dev\` and \`target=staging\`)
- Distinct from the existing Platform tab (which documents reusable infra components, not the IDP-as-a-service)

## Follow-ups (not in this PR — incremental)
- \`build/cli\` — CLI command reference
- \`build/concepts\` — projects / dev clusters / preview envs
- \`build/troubleshooting\` — common errors

## Preview
Mintlify auto-deploys this branch.