### PR TITLE
docs: bring portal + manifest pages up to current feature set

### DIFF
--- a/build/concepts/pushes.mdx
+++ b/build/concepts/pushes.mdx
@@ -86,6 +86,14 @@ grounds push list --status=ready        # filter by terminal state
 
 In the portal, the project's **Pushes** page shows the same list with status badges and clickable detail pages.
 
+## Rolling back
+
+If a successful push introduced a bug and you need the previous image back, open the app's **Pushes** tab in the portal and click **Roll back** on the prior push. Forge re-deploys that push's already-built image without re-running kaniko, so the rollback lands in seconds. The rollback creates a fresh push row pointing at the same `imageTag`, so the audit log records the action.
+
+## Promoting a staging push
+
+For pushes that targeted `staging` and reached `ready`, the portal's **Pushes** tab also shows a **Promote** action. Promote copies the built image into a new push targeting `dev` — no rebuild, no kaniko run. Use it to ship the exact artifact you just verified in a preview env, instead of re-running the build pipeline and risking a different image (e.g., upstream base-image drift).
+
 ## What survives a push
 
 - The previous deployment for `dev` is **replaced**. State (world chunks, plugin data files) survives because the volume is attached at the namespace level — but anything in-memory is lost.

--- a/build/gradle-plugin/groundsPush.mdx
+++ b/build/gradle-plugin/groundsPush.mdx
@@ -24,8 +24,9 @@ This is the task the CLI's `grounds push` invokes under the hood. Run it directl
 | Flag | Purpose |
 |---|---|
 | `--target=<dev\|staging>` | Override the manifest's target. **Highest precedence**. |
+| `--force` | Skip forge's content-hash dedup and force a fresh build. Use when the upstream base image moved under a stable tag, or when you want to re-observe the build flow. |
 
-That's it. Everything else is configured via the [`groundsPush` extension](/build/gradle-plugin/setup#the-groundspush-extension) or `grounds.yaml`.
+Everything else is configured via the [`groundsPush` extension](/build/gradle-plugin/setup#the-groundspush-extension) or `grounds.yaml`.
 
 ## Output
 

--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -26,6 +26,8 @@ resources:
   memory: 1Gi
 ```
 
+Multi-plugin servers ship multiple JARs onto one Paper / Velocity / gamemode workload — see [`plugins`](#plugins-optional) below.
+
 ## Fields
 
 ### `name` (required)
@@ -72,6 +74,35 @@ When to set it explicitly:
 
 - You produce multiple JARs and want to ensure the right one is picked.
 - You build with something other than `shadowJar` / `jar`.
+
+### `plugins` (optional)
+
+A list of 2–10 JAR paths bundled into a single Paper / Velocity / gamemode server. Useful when you want to test plugin interaction (economy + chat + teams) on one running instance instead of pushing each plugin as its own server.
+
+```yaml
+name: combo
+type: plugin-paper
+baseImage: paper
+plugins:
+  - sub-projects/economy/build/libs/economy.jar
+  - sub-projects/chat/build/libs/chat.jar
+  - sub-projects/teams/build/libs/teams.jar
+```
+
+The Gradle plugin packs the listed JARs into a tar.gz and forge unpacks them into `/app/plugins/` in manifest order (a numeric prefix preserves load order, since Paper's `pluginsFolder` scan is filesystem-ordered).
+
+Constraints:
+
+- Mutually exclusive with `jar:` — pick one shape per manifest.
+- Forbidden for `type: service` (services have a single-jar `ENTRYPOINT`; multi-plugin has no meaningful semantics there).
+- 2 minimum (single-plugin uses `jar:`), 10 maximum, 50 MB total upload (same cap as a single JAR).
+- All listed paths must already exist when `groundsPush` runs. If your JARs come from sub-projects, depend on their build tasks:
+
+```kotlin build.gradle.kts
+tasks.named("groundsPush") {
+    dependsOn(":economy:jar", ":chat:jar", ":teams:jar")
+}
+```
 
 ### `target` (optional)
 

--- a/build/portal.mdx
+++ b/build/portal.mdx
@@ -28,9 +28,19 @@ Active preview environments for the current project. Per-row dropdown menu has:
 
 Status badges reflect the underlying push: `ready`, `pending`, `building`, `deploy_failed`, etc. The hostname is a clickable external link when status is `ready`.
 
-### Deployments
+### Apps
 
-The active deployments view (one row per running app, irrespective of which push placed it there). Click into one for live logs. This is the right surface to use when something is **currently broken** — the latest push might have succeeded but the pod is now crashlooping.
+One row per running app (irrespective of which push placed it there). Click into one to drill into per-app surfaces:
+
+- **Logs** — live pod logs, SSE-tailed.
+- **Pushes** — every push that targeted this app, newest first. Per-row actions:
+  - **Roll back** — re-deploys an earlier push's image without re-building. Lands in seconds and creates a fresh push row pointing at the same `imageTag`, so the audit log records it.
+  - **Promote** — on a `ready` push that targeted `staging`, copies the built image into a new `dev` push. Skips the rebuild and ships the staging artifact you just verified.
+- **Previews** — preview environments scoped to this app.
+- **Env** — per-app environment variables. Stored on the deployment row in forge, injected after the built-in `GROUNDS_*` keys (which the API rejects up front, so user values can't shadow platform context). Saving triggers a rolling restart.
+- **Settings** — resource overrides (CPU + memory) that override the type-default for this app. Persisted on the deployment row and live-patched onto the running pod, so changes take effect without a re-push. Plus the Danger Zone "Delete app" flow (tears down the Service + Deployment; the image stays in the registry).
+
+This is the right surface to use when something is **currently broken** — the latest push might have succeeded but the pod is now crashlooping, or the new release introduced a bug you want to roll back.
 
 ### Members
 
@@ -40,6 +50,8 @@ Project members with roles. Owners can:
 - **Invite link** — generate a single-use URL, pick role + expiry.
 - Per-row: change role (owner/editor/viewer), remove member.
 - Self-removal (Leave project) is allowed for any member; forge enforces last-owner protection.
+
+The same page hosts the **Minecraft whitelist** card — the list of Mojang accounts your project's `paper` / `paper-gamemode` servers will let join. Add/remove by gamertag; forge resolves each entry against Mojang and surfaces the validation result inline (so a typo'd name fails at edit time, not at server-join time). The list is pushed live to every running Paper pod via `plugin-grounds-platform`.
 
 ### Settings
 
@@ -62,10 +74,9 @@ The portal supports system, light, and dark themes via the `data-mode` attribute
 
 ## What it can't do (yet)
 
-The portal is feature-complete for **observation** and **member/token management**. Things still CLI-only:
+Things still CLI-only:
 
 - Initiating a push (you upload a JAR, which a browser file picker won't carry well across CI etc.).
-- Promoting a push to production.
 - Bulk operations on pushes or previews.
 
-Most "make changes" workflows go through the CLI; the portal is the read + administer surface.
+Day-to-day operations after the initial push — rolling back, promoting a staging push to dev, editing env vars, adjusting resources, managing the whitelist — all live in the portal.


### PR DESCRIPTION
## Summary
Catches the user-facing docs up to features that shipped in portal 0.25.0 and forge 1.18.x–1.19.0:
- **Manifest** — new `plugins:` field for multi-plugin bundles (2..10 JARs, mutually exclusive with `jar:`)
- **Portal** — replaced the stale "Deployments" stub with the actual per-app drill-down (Logs, Pushes with rollback + staging→dev promote, Previews, Env, Settings); added the Minecraft whitelist card to Members
- **Pushes concept** — documented rollback and promote
- **groundsPush** — added the `--force` flag

## Test plan
- [ ] `mintlify dev` renders the changed pages without warnings
- [ ] All anchor links resolve (manifest's `#plugins-optional` fragment)