### PR TITLE
docs(manifest): link to multi-plugin-sample repo

### DIFF
--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -79,6 +79,8 @@ When to set it explicitly:
 
 A list of 2–10 plugin sources bundled into a single Paper / Velocity / gamemode server. Useful when you want to test plugin interaction (economy + chat + teams) on one running instance instead of pushing each plugin as its own server.
 
+A working end-to-end example lives at [groundsgg/multi-plugin-sample](https://github.com/groundsgg/multi-plugin-sample) — two trivial Paper plugins bundled via `:gradle-project` refs. Clone, run `./gradlew groundsPush`, see both plugins boot on one server.
+
 Each entry is one of four source kinds, distinguished by prefix:
 
 ```yaml


### PR DESCRIPTION
## Summary
Adds a one-line callout in the \`plugins[]\` section pointing to the new public sample repo at [groundsgg/multi-plugin-sample](https://github.com/groundsgg/multi-plugin-sample). Lets readers go straight from the field reference to a runnable end-to-end demo.

## Test plan
- [x] Mintlify link-rot validation (the new external URL resolves)