### PR TITLE
docs: update minecraft access docs

### DIFF
--- a/build/ci-tokens.mdx
+++ b/build/ci-tokens.mdx
@@ -21,6 +21,7 @@ A service-account token can do anything an `editor` can do — within the projec
 - ✓ Retry pushes
 - ✓ List, show, pin, unpin previews
 - ✓ Read deployment logs
+- ✓ Manage Minecraft whitelist entries when the token creator still has `owner` or `editor` access
 
 What it **cannot** do (privilege-escalation guard):
 
@@ -40,7 +41,7 @@ Only project **owners** can mint.
 ### Portal
 
 1. Open the project.
-2. **Settings** → **Service accounts**.
+2. Go to **API tokens**.
 3. Click **New token**, name it (`ci-github-actions`, `release-bot`), pick an expiry.
 4. Copy the secret immediately — you won't see it again.
 
@@ -88,7 +89,7 @@ Tokens never auto-rotate. The platform doesn't refresh them or reissue silently.
 
 ## Audit
 
-Every token mint, use, and revocation is recorded in the project's audit feed (portal **Settings** → **Audit**). Useful when investigating a compromise or wondering "who pushed at 3am yesterday".
+Every token mint, use, and revocation is recorded in the project's audit feed (portal **Audit**). Useful when investigating a compromise or wondering "who pushed at 3am yesterday".
 
 ## What if my token leaks?
 

--- a/build/concepts/projects-and-teams.mdx
+++ b/build/concepts/projects-and-teams.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Projects & teams"
-description: "Projects scope everything you do on the platform — pushes, previews, members, tokens."
+description: "Projects scope everything you do on the platform — pushes, previews, members, tokens, and Minecraft access."
 ---
 
 Every push, preview, and token belongs to a **project**. A project is your collaboration unit: a set of members with roles, working on the same plugin or service.
@@ -9,11 +9,11 @@ Every push, preview, and token belongs to a **project**. A project is your colla
 
 There are three roles, with strictly nested permissions:
 
-| Role | Push | View pushes | Manage previews | Invite / remove members | Mint tokens |
-|---|---|---|---|---|---|
-| `viewer` | — | ✓ | — | — | — |
-| `editor` | ✓ | ✓ | ✓ | — | — |
-| `owner` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Role | Push | View pushes | Manage previews | Manage Minecraft access | Invite / remove members | Mint tokens |
+|---|---|---|---|---|---|---|
+| `viewer` | — | ✓ | — | — | — | — |
+| `editor` | ✓ | ✓ | ✓ | ✓ | — | — |
+| `owner` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 Roles are project-scoped. You can be an `owner` on one project and a `viewer` on another.
 
@@ -55,10 +55,34 @@ For people who haven't signed up yet, mint a one-time invite link:
 
 Invite links are **single-use** — redemption is atomic, so simultaneous clicks can't both succeed. They cannot be used to grant `owner` (only existing owners can promote).
 
+## Minecraft access
+
+Minecraft access is project-scoped by default, with an optional app-specific layer for one Minecraft app.
+
+There are three sources:
+
+| Source | Managed from | Access granted |
+|---|---|---|
+| Linked project member | Members page | Every Minecraft app in the project |
+| Project-wide player | Members page → Minecraft whitelist | Every Minecraft app in the project |
+| App-specific player | App settings → Minecraft whitelist | Only that app |
+
+Project members who sign in with a linked Minecraft Java account appear as **Linked member** entries. These entries inherit access from membership and are read-only in the whitelist list. To remove that access, remove the project member or update the member's linked Minecraft identity.
+
+Owners and editors can add **Project-wide** players from the Members page. Use this for playtesters or operators who need to join Minecraft servers but should not access the project in the portal.
+
+Owners and editors can add **App-specific** players from a Minecraft app's settings page. Use this for temporary access to one server without granting access to every Minecraft app in the project.
+
+When you add a Minecraft username, forge resolves it to a Mojang UUID immediately. The UI continues to show the username, but access is tied to the UUID so later username changes do not strand the whitelist entry.
+
+<Note>
+Only Java identities are used for Minecraft app access today. Bedrock ownership from the identity provider does not grant Java server access.
+</Note>
+
 ## Service-account tokens
 
 For unattended use (CI, scripts, bots) projects can mint long-lived `gnds_*` API tokens scoped to a single project. See [CI / service-account tokens](/build/ci-tokens).
 
 ## Audit
 
-Membership and role changes are recorded in the project's audit feed (visible in the portal under Settings → Audit). Token mint and revocation events appear there too.
+Membership, role, token, deployment, push, project, and Minecraft whitelist changes are recorded in the project's audit feed (visible in the portal under **Audit**).

--- a/build/portal.mdx
+++ b/build/portal.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Portal"
-description: "The web UI at portal.platform.grnds.io — projects, members, pushes, previews."
+description: "The web UI at portal.platform.grnds.io — projects, apps, members, Minecraft access, pushes, and previews."
 ---
 
 The portal is the visual side of the platform. Sign in with your Grounds Account at [portal.platform.grnds.io](https://portal.platform.grnds.io); membership in any project lands you on a project switcher.
@@ -13,11 +13,28 @@ The CLI and the portal share the same forge backend — every operation in one i
 
 Top-left dropdown. Switch active project; affects every page below it. The selected project is remembered in your browser's local storage.
 
+If you open a direct link to an app or other resource that belongs to another project you can access, the portal switches to that project and shows the resource instead of leaving you on a 404.
+
+### Apps
+
+The apps overview shows current deployments grouped by manifest name. Each app row shows type, status, latest activity, and whether the workspace is paused.
+
+Open an app to drill into per-app surfaces:
+
+- **Overview** — status, runtime metrics, active deployment, and quick actions.
+- **Logs** — live pod logs, SSE-tailed.
+- **Pushes** — every push that targeted this app, newest first.
+- **Previews** — preview environments scoped to this app.
+- **Env** — per-app environment variables. User-defined values cannot shadow platform-managed `GROUNDS_*` keys.
+- **Settings** — runtime resource overrides, Minecraft access for Minecraft app types, and the app delete flow.
+
 ### Pushes
 
-The history list for the current project: status badge, name, type, target, image tag, creation time. Click a row to open the push detail page with the full build + deploy log stream (SSE-tailed if still running, replayed if completed).
+The history list for the current project: status badge, name, type, target, short push hash, and creation time. Click a row to open the push detail page with the full build + deploy log stream (SSE-tailed if still running, replayed if completed).
 
 Empty state explains how to make your first push if you haven't yet.
+
+From a push detail page you can retry a failed push, promote ready staging pushes, and roll back an app to a previously deployed push when the action is available.
 
 ### Previews
 
@@ -26,21 +43,24 @@ Active preview environments for the current project. Per-row dropdown menu has:
 - **Pin (skip auto-cleanup)** — sets `pinned=true`, env survives past TTL.
 - **Unpin (re-enable cleanup)** — sets `pinned=false`, TTL recomputed from now.
 
-Status badges reflect the underlying push: `ready`, `pending`, `building`, `deploy_failed`, etc. The hostname is a clickable external link when status is `ready`.
+Status badges reflect the underlying push: `ready`, `received`, `building`, `deploy_failed`, etc. The hostname is a clickable external link when status is `ready` for web services. Minecraft previews show the server address to paste into Minecraft.
 
-### Apps
+### Deployments
 
-One row per running app (irrespective of which push placed it there). Click into one to drill into per-app surfaces:
+The active deployments view shows one row per running app, regardless of which push placed it there. Click into a deployment for live logs and runtime details.
 
-- **Logs** — live pod logs, SSE-tailed.
-- **Pushes** — every push that targeted this app, newest first. Per-row actions:
-  - **Roll back** — re-deploys an earlier push's image without re-building. Lands in seconds and creates a fresh push row pointing at the same `imageTag`, so the audit log records it.
-  - **Promote** — on a `ready` push that targeted `staging`, copies the built image into a new `dev` push. Skips the rebuild and ships the staging artifact you just verified.
-- **Previews** — preview environments scoped to this app.
-- **Env** — per-app environment variables. Stored on the deployment row in forge, injected after the built-in `GROUNDS_*` keys (which the API rejects up front, so user values can't shadow platform context). Saving triggers a rolling restart.
-- **Settings** — resource overrides (CPU + memory) that override the type-default for this app. Persisted on the deployment row and live-patched onto the running pod, so changes take effect without a re-push. Plus the Danger Zone "Delete app" flow (tears down the Service + Deployment; the image stays in the registry).
+### App details and actions
 
-This is the right surface to use when something is **currently broken** — the latest push might have succeeded but the pod is now crashlooping, or the new release introduced a bug you want to roll back.
+Use the app detail pages when something is **currently broken** — the latest push might have succeeded but the pod is now crashlooping, or the new release introduced a bug you want to roll back.
+
+Available app actions include:
+
+- **Retry** — re-run a failed push using the server-stored JAR and manifest.
+- **Roll back** — redeploy an earlier push image without rebuilding.
+- **Promote** — copy a ready staging artifact into a new `dev` push.
+- **Push command** — copy the Gradle command to upload a new push from your terminal.
+- **Runtime overrides** — override CPU and memory without editing `grounds.yaml`.
+- **Delete app** — tear down the app Service and Deployment. The image remains in the registry.
 
 ### Members
 
@@ -51,14 +71,37 @@ Project members with roles. Owners can:
 - Per-row: change role (owner/editor/viewer), remove member.
 - Self-removal (Leave project) is allowed for any member; forge enforces last-owner protection.
 
-The same page hosts the **Minecraft whitelist** card — the list of Mojang accounts your project's `paper` / `paper-gamemode` servers will let join. Add/remove by gamertag; forge resolves each entry against Mojang and surfaces the validation result inline (so a typo'd name fails at edit time, not at server-join time). The list is pushed live to every running Paper pod via `plugin-grounds-platform`.
+The Members page also manages project-wide Minecraft access:
 
-### Settings
+- **Linked members** — project members with a linked Minecraft Java account inherit access to Minecraft apps in the project.
+- **Project-wide players** — Minecraft usernames added directly to the project whitelist. These players can join Minecraft apps without being project members.
+- Owners and editors can add or remove project-wide players. Linked member entries are read-only in the whitelist list; update the member or their linked identity instead.
 
-- **Project info** — name, slug.
-- **Service accounts** — list, mint, revoke project-scoped API tokens. See [CI tokens](/build/ci-tokens).
-- **Audit** — recent member, token, and admin events.
-- **Danger zone** — archive / delete the project.
+### Minecraft access
+
+Minecraft apps combine three access sources:
+
+| Source | Where it is managed | Applies to |
+|---|---|---|
+| Linked member | Members page | Every Minecraft app in the project |
+| Project-wide | Members page → Minecraft whitelist | Every Minecraft app in the project |
+| App-specific | App settings → Minecraft whitelist | One Minecraft app |
+
+On an app settings page, the **Minecraft access** card shows the effective list for that app. Inherited linked member and project-wide entries are shown as read-only. App-specific entries can be added or removed there by owners and editors.
+
+When you add a player, enter the Minecraft Java username. Forge resolves it to a Mojang UUID when the entry is created, so later username changes do not break access.
+
+### API tokens
+
+Project owners can create, filter, and revoke project-scoped API tokens from the **API tokens** page. See [CI tokens](/build/ci-tokens).
+
+### Audit
+
+The **Audit** page shows recent project activity, including member, token, project, deployment, push, and Minecraft whitelist events.
+
+### Account settings
+
+The account settings page shows your Grounds Account identity, linked Minecraft Java username and UUID, theme selector, kubeconfig shortcut, and sign-out button.
 
 ### Account
 
@@ -74,9 +117,9 @@ The portal supports system, light, and dark themes via the `data-mode` attribute
 
 ## What it can't do (yet)
 
-Things still CLI-only:
+The portal is feature-complete for **observation**, **member/token management**, and Minecraft access management. Things still CLI-only:
 
-- Initiating a push (you upload a JAR, which a browser file picker won't carry well across CI etc.).
+- Uploading a new push artifact. The portal can show the push command, but the upload still runs from the CLI or Gradle plugin.
 - Bulk operations on pushes or previews.
 
 Day-to-day operations after the initial push — rolling back, promoting a staging push to dev, editing env vars, adjusting resources, managing the whitelist — all live in the portal.

--- a/build/troubleshooting.mdx
+++ b/build/troubleshooting.mdx
@@ -151,7 +151,7 @@ The hostname only routes to a `ready` pod — during a redeploy or crashloop you
 You're authenticated but not a member of the project the request targets. Check:
 
 - The project ID in `--project` / `GROUNDS_PROJECT` / `config.toml`.
-- Your role in the portal (Settings → Members).
+- Your role in the portal on the **Members** page.
 
 If you used a service-account token, it's hard-pinned to its minting project — you cannot use it elsewhere.
 


### PR DESCRIPTION
# Pull Request

## Description
Update the docs for the current portal Minecraft access model and clean up stale portal navigation references.

This documents linked member, project-wide, and app-specific Minecraft access; updates portal page descriptions for apps, pushes, previews, tokens, audit, and account settings; and fixes outdated `Settings → ...` references.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues
- Fixes #

## Testing
- [ ] Unit tests pass
- [ ] Manual testing completed
- [ ] New tests added for new functionality

Validation:
- `mintlify validate`
- `git diff --check --cached`

## Checklist
- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed) - not needed
- [x] Documentation has been updated (if needed)
