### PR TITLE
docs: restructure build developer journey

### DIFF
--- a/build/cli/configuration.mdx
+++ b/build/cli/configuration.mdx
@@ -28,6 +28,7 @@ What lives there:
 |---|---|
 | `credentials.json` | Created by `grounds login`. Refresh + access tokens. `0600`. |
 | `config.toml` | Optional. User-managed defaults. |
+| `workspace.yaml` | Optional. Local plugin workspace overrides for `grounds push --local` and `--with-local`. |
 
 ## config.toml
 
@@ -68,6 +69,17 @@ grounds-prod push --target=staging
 ```
 
 Each dir has its own `credentials.json` and `config.toml`.
+
+The same directory also owns `workspace.yaml`, so isolated profiles can have
+their own local plugin mappings:
+
+```bash
+GROUNDS_CONFIG_DIR=/path/to/sample/.grounds-config grounds workspace list
+GROUNDS_CONFIG_DIR=/path/to/sample/.grounds-config grounds push --with-local
+```
+
+See [Local plugin workspaces](/build/cli/workspace) for the workspace file and
+commands.
 
 ## Resetting
 

--- a/build/cli/preview.mdx
+++ b/build/cli/preview.mdx
@@ -5,6 +5,8 @@ description: "List, inspect, and pin staging preview environments."
 
 The `preview` subtree manages [preview environments](/build/concepts/preview-environments) — the ephemeral envs created by `grounds push --target=staging`.
 
+For the developer workflow, see [Share staging previews](/build/share-staging-previews).
+
 ## Synopsis
 
 ```text

--- a/build/cli/push.mdx
+++ b/build/cli/push.mdx
@@ -8,7 +8,7 @@ description: "Build with Gradle, upload to forge, deploy to a target."
 ## Synopsis
 
 ```text
-grounds push [--target=dev|staging] [--project <id>]
+grounds push [--target=dev|staging] [--project <id>] [--local <id>[,<id>]] [--with-local]
 grounds push retry <pushId>
 grounds push list [--target T] [--status S] [--limit N]
 ```
@@ -18,6 +18,9 @@ grounds push list [--target T] [--status S] [--limit N]
 ```bash
 grounds push --target=dev       # default
 grounds push --target=staging
+grounds push --local plugin-chat
+grounds push --local plugin-chat,plugin-permissions
+grounds push --with-local
 ```
 
 Runs `./gradlew groundsPush --target=<t>` in the current directory. The Gradle plugin handles:
@@ -29,6 +32,43 @@ Runs `./gradlew groundsPush --target=<t>` in the current directory. The Gradle p
 - Exiting with a non-zero code on any terminal failure.
 
 The CLI exits with the same code Gradle exits with.
+
+By default, `grounds push` uses the release sources declared in
+`grounds.yaml`. Local plugin builds are opt-in through
+[workspace overrides](/build/cli/workspace).
+
+### Local plugin overrides
+
+Use `--local` when one or more entries in `grounds.yaml: plugins` should come
+from your local workspace instead of the release source:
+
+```bash
+grounds push --target=dev --local plugin-agones
+grounds push --target=dev --local plugin-agones,plugin-player
+grounds push --target=dev --local plugin-agones --local plugin-player
+```
+
+`--local` accepts both comma-separated IDs and repeated flags. IDs must match
+the structured plugin `id` in `grounds.yaml`.
+
+Use `--with-local` when every enabled workspace mapping present in
+`grounds.yaml` should be replaced by its local artifact:
+
+```bash
+grounds push --target=dev --with-local
+```
+
+Before Gradle runs, the CLI prints the effective source table:
+
+```text
+Bundle sources:
+ID              Variant   Effective   Value
+plugin-agones   velocity  local       /home/alice/grounds/plugin-agones/velocity/build/libs/plugin-agones-velocity.jar
+plugin-player   velocity  release     github:groundsgg/plugin-player@v0.1.0
+```
+
+The table is the confirmation step. It shows which plugins use local artifacts
+and which still use release sources.
 
 ## push retry
 
@@ -96,6 +136,9 @@ grounds logs deployment my-cool-plugin
 ```
 
 ## Exit codes
+
+For a practical failure investigation flow, see
+[Debug pushes and deployments](/build/debug-pushes).
 
 | Code | Meaning |
 |---|---|

--- a/build/cli/workspace.mdx
+++ b/build/cli/workspace.mdx
@@ -1,0 +1,164 @@
+---
+title: "Local plugin workspaces"
+description: "Use local plugin builds as opt-in overrides for multi-plugin pushes."
+---
+
+Local plugin workspaces let you test several independent plugin repositories
+together without putting machine-specific paths in `grounds.yaml`.
+
+For the internal step-by-step workflow, start with
+[Work with local plugin workspaces](/build/local-plugin-workspaces).
+
+The manifest stays portable and points at release sources. Your local
+`workspace.yaml` maps plugin IDs and variants to repositories on your machine.
+`grounds push` only uses those local builds when you ask for them with
+`--local` or `--with-local`.
+
+<Tip>
+Use workspace overrides for dependency development: app repo in one directory,
+plugin repos as siblings, and release sources as the default for every teammate
+and CI run.
+</Tip>
+
+## Config file
+
+Workspace mappings live in the CLI config directory:
+
+| OS | Default workspace file |
+| --- | --- |
+| Linux | `~/.config/grounds/workspace.yaml` |
+| macOS | `~/Library/Application Support/grounds/workspace.yaml` |
+| Windows | `%APPDATA%\grounds\workspace.yaml` |
+
+The global `--config <dir>` flag and `GROUNDS_CONFIG_DIR` environment variable
+move this file together with the rest of the CLI config.
+
+```bash
+GROUNDS_CONFIG_DIR=/path/to/sample/.grounds-config grounds workspace list
+```
+
+See [Configuration](/build/cli/configuration) for the full config directory
+rules.
+
+## Manifest shape
+
+Local overrides match entries in `grounds.yaml` by `id` and optional `variant`:
+
+```yaml grounds.yaml
+name: velocity-stack
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+`source` remains the default release source. `id` and `variant` give the CLI a
+stable key for local replacement.
+
+## Add mappings explicitly
+
+Use `workspace add` when you know the repository path and artifact layout:
+
+```bash
+grounds workspace add plugin-agones /home/alice/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace add plugin-player /home/alice/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+```
+
+| Flag | Purpose |
+| --- | --- |
+| `--variant <name>` | Stores a variant-specific mapping, for example `paper`, `velocity`, or `minestom`. |
+| `--artifact <glob>` | Artifact glob relative to the repository path. Defaults to `build/libs/*.jar`, or `<variant>/build/libs/*.jar` for variant mappings. |
+| `--build <command>` | Build command run inside the repository before artifact resolution. Defaults to `./gradlew build`, or `./gradlew :<variant>:shadowJar` for variant mappings. |
+| `--disabled` | Adds the mapping disabled. Disabled mappings are ignored by `--with-local`. |
+
+Artifact globs should resolve to the deployable JAR. If multiple JARs match,
+the resolver ignores common auxiliary JARs such as `-sources` and `-javadoc`
+and prefers shadow/all artifacts.
+
+## Scan sibling repos
+
+Use `workspace scan` to discover local plugin repositories under one or more
+directories:
+
+```bash
+grounds workspace scan /home/alice/grounds
+grounds workspace scan /home/alice/grounds --yes
+```
+
+Without `--yes`, the CLI prints the proposed mappings and asks before writing.
+With `--yes`, it writes immediately.
+
+<Note>
+Scan does not overwrite existing mappings. If you have custom build commands or
+artifact paths, they stay in place.
+</Note>
+
+## Inspect and toggle mappings
+
+```bash
+grounds workspace list
+grounds workspace doctor
+
+grounds workspace enable plugin-agones velocity
+grounds workspace enable plugin-agones velocity --disable
+```
+
+`workspace list` prints each mapping with ID, variant, enabled state, path,
+artifact, and build command. `workspace doctor` checks whether configured repo
+paths exist.
+
+## Push with local overrides
+
+Use release sources by default:
+
+```bash
+grounds push --target=dev
+```
+
+Override one or more plugins for this push:
+
+```bash
+grounds push --target=dev --local plugin-agones
+grounds push --target=dev --local plugin-agones,plugin-player
+grounds push --target=dev --local plugin-agones --local plugin-player
+```
+
+Override every enabled workspace entry that appears in `grounds.yaml`:
+
+```bash
+grounds push --target=dev --with-local
+```
+
+Before Gradle runs, the CLI prints the effective source table:
+
+```text
+Bundle sources:
+ID              Variant   Effective   Value
+plugin-agones   velocity  local       /home/alice/grounds/plugin-agones/velocity/build/libs/plugin-agones-velocity.jar
+plugin-player   velocity  release     github:groundsgg/plugin-player@v0.1.0
+```
+
+`Effective` tells you whether the push uses the release source from
+`grounds.yaml` or a local artifact from `workspace.yaml`.
+
+## Behavior and safety
+
+- Local overrides apply only to the push where you pass `--with-local` or `--local`.
+- The CLI builds local repos before resolving their artifacts.
+- Git metadata is best-effort. Non-git directories still work.
+- Local filesystem paths are passed to Gradle through a generated resolved
+  plugins file; they do not need to appear in `grounds.yaml`.
+- Local path values are not shown in portal source labels. Portal shows a safe
+  artifact label and records that the effective source was local.

--- a/build/concepts/preview-environments.mdx
+++ b/build/concepts/preview-environments.mdx
@@ -5,6 +5,9 @@ description: "Ephemeral, public, per-push environments — the result of every s
 
 Every `grounds push --target=staging` creates a **preview environment**: a fresh namespace, a fresh deployment, and a public URL. They're built for sharing — review apps, demos, end-to-end test runs against a real cluster.
 
+For the step-by-step staging workflow, see
+[Share staging previews](/build/share-staging-previews).
+
 ## Anatomy of a preview env
 
 | Property | Value |

--- a/build/debug-pushes.mdx
+++ b/build/debug-pushes.mdx
@@ -75,14 +75,27 @@ cd ~/grounds/plugin-agones
 ```
 
 Fix any compilation, test, or packaging issue there first. Then return to the
-app repo and run the push task with a stacktrace:
+app repo.
+
+For pushes that do **not** use `--local` or `--with-local`, run the Gradle task
+with a stacktrace:
 
 ```bash
 ./gradlew groundsPush --target=dev --stacktrace
 ```
 
-This separates local Gradle failures from CLI wrapper behavior. For task-level
-details, see [groundsPush](/build/gradle-plugin/groundsPush).
+For pushes that **do** use local overrides, rerun the CLI command with the same
+local flags and add verbose logging:
+
+```bash
+grounds push --target=dev --local plugin-agones --verbose
+grounds push --target=dev --with-local --verbose
+```
+
+Direct `groundsPush` inspection is useful for task-level Gradle failures, but it
+does not reproduce CLI workspace resolution for local overrides because that
+resolution happens before Gradle starts. For task-level details, see
+[groundsPush](/build/gradle-plugin/groundsPush).
 
 ## 5. Inspect Portal
 

--- a/build/debug-pushes.mdx
+++ b/build/debug-pushes.mdx
@@ -1,0 +1,135 @@
+---
+title: "Debug pushes and deployments"
+description: "Diagnose failed local builds, uploads, Forge builds, and deployments."
+---
+
+Use this workflow when `grounds push` fails, local plugin overrides are not
+being picked up, or a deployment reaches Forge but never becomes ready.
+
+| Layer | Typical signal |
+| --- | --- |
+| Workspace resolution | `local workspace entry ... not found` |
+| Local build | Gradle failure from the dependency repo build command |
+| Upload | HTTP, auth, file size, or network error |
+| Forge build | `build_failed` |
+| Deploy | `deploy_failed`, pod scheduling, readiness, or crash loop |
+
+## 1. Read the CLI output
+
+Start at the first failed layer in the terminal output. `grounds push` prints
+the local source decision, Gradle output, upload result, Forge build status, and
+deploy status in order.
+
+Do not jump straight to deployment logs if the failure happened before upload or
+before `build_succeeded`. Match the terminal status to the table above, then
+debug the earliest failing layer.
+
+For exact push behavior, flags, output, and exit codes, see
+[grounds push](/build/cli/push).
+
+## 2. Check local workspace mappings
+
+Local overrides only work when the CLI can resolve the plugin ID in
+`grounds.yaml` to a workspace entry. List the workspace entries first:
+
+```bash
+grounds workspace list
+```
+
+Then run the workspace doctor from the app repo where you push:
+
+```bash
+grounds workspace doctor
+```
+
+Check that:
+
+- The plugin ID matches the structured `plugins:` entry in `grounds.yaml`.
+- The workspace path points at the repo you expect.
+- The entry is enabled when using `--with-local`.
+- The dependency repo still builds the variant that the app needs.
+
+For workspace command details, see the CLI workspace reference at
+[workspace overrides](/build/cli/workspace).
+
+## 3. Check the source table
+
+Before Gradle runs, the CLI prints the effective source table. Treat that table
+as the source of truth for this push.
+
+Confirm that the plugin you expected to override shows `local`, and that the
+path points at the artifact from the intended repo. If it still shows
+`release`, the push is using the manifest source instead of your local build.
+
+If the source table is wrong, fix the workspace mapping or the `--local` /
+`--with-local` flags before inspecting Forge or deployment state.
+
+## 4. Inspect Gradle directly
+
+When the source table is correct but the local build fails, run the dependency
+repo build command directly:
+
+```bash
+cd ~/grounds/plugin-agones
+./gradlew :velocity:shadowJar
+```
+
+Fix any compilation, test, or packaging issue there first. Then return to the
+app repo and run the push task with a stacktrace:
+
+```bash
+./gradlew groundsPush --target=dev --stacktrace
+```
+
+This separates local Gradle failures from CLI wrapper behavior. For task-level
+details, see [groundsPush](/build/gradle-plugin/groundsPush).
+
+## 5. Inspect Portal
+
+If upload succeeded and Forge created a push, inspect the push in
+[Portal](/build/portal). Use the Portal view to confirm:
+
+- The push target is the one you intended.
+- The manifest and plugin sources match the CLI output.
+- The failure is in build or deploy, not workspace resolution.
+- The latest push is the one you are debugging.
+
+Portal is useful when the CLI disconnected, timed out while streaming, or the
+push history has multiple retries.
+
+## 6. Tail deployment logs
+
+When the CLI reports `deploy_failed`, `CrashLoopBackOff`, readiness failures, or
+502s from a preview URL, tail the live deployment logs:
+
+```bash
+grounds logs deployment <app-name>
+```
+
+Use the deployment name printed by `grounds push` or shown in Portal. Look for
+plugin startup exceptions, Java version mismatches, missing runtime
+dependencies, readiness failures, or memory pressure.
+
+For symptom-specific checks, see [Troubleshooting](/build/troubleshooting).
+
+## 7. Retry transient failures
+
+Retry only after deciding the failure was transient or after fixing the platform
+condition that caused it. Good retry candidates include registry hiccups,
+temporary image pull failures, interrupted deploy reconciliation, or CLI stream
+timeouts after Forge accepted the push.
+
+```bash
+grounds push retry <push-id>
+```
+
+Retrying creates a new push row and reuses the server-stored manifest and
+artifact. It does not rebuild local sources or upload new files. If you changed
+code, run a new `grounds push` instead.
+
+## Reference
+
+- [Troubleshooting](/build/troubleshooting)
+- [grounds push](/build/cli/push)
+- [groundsPush](/build/gradle-plugin/groundsPush)
+- [Portal](/build/portal)

--- a/build/gradle-plugin/groundsPush.mdx
+++ b/build/gradle-plugin/groundsPush.mdx
@@ -30,6 +30,38 @@ Forge performs the final runtime image selection server-side from the [base imag
 
 Everything else is configured via the [`groundsPush` extension](/build/gradle-plugin/setup#the-groundspush-extension) or `grounds.yaml`.
 
+## Multi-plugin bundles
+
+When `grounds.yaml` contains `plugins:`, `groundsPush` resolves every source,
+packs the resolved JARs into a `tar.gz` bundle, and uploads that bundle as the
+artifact. Forge unpacks it into `/app/plugins/` in manifest order.
+
+```yaml grounds.yaml
+name: velocity-stack
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+If you run `grounds push --local ...` or `grounds push --with-local`, the CLI
+resolves local workspace artifacts before Gradle starts and passes those
+resolved sources to `groundsPush`. The shared manifest still contains release
+sources; local filesystem paths stay in the CLI workspace config.
+
+<Note>
+Bundle uploads are capped at 100 MB. Keep dependency JARs out of the plugin
+artifact when the runtime already provides them.
+</Note>
+
+For the developer workflow around this feature, see
+[Test multi-plugin stacks](/build/multi-plugin-stacks).
+
 ## Output
 
 ```

--- a/build/gradle-plugin/setup.mdx
+++ b/build/gradle-plugin/setup.mdx
@@ -47,7 +47,7 @@ In your **plugin module's** `build.gradle.kts` (the one that produces the JAR):
 
 ```kotlin build.gradle.kts
 plugins {
-    id("gg.grounds.push") version "0.5.0"
+    id("gg.grounds.push") version "0.9.1"
 }
 ```
 
@@ -89,7 +89,7 @@ At `afterEvaluate`, the plugin looks for tasks named (in order) `shadowJar`, `ja
 ```kotlin build.gradle.kts
 plugins {
     id("com.gradleup.shadow") version "8.3.5"
-    id("gg.grounds.push") version "0.5.0"
+    id("gg.grounds.push") version "0.9.1"
 }
 
 tasks.shadowJar {

--- a/build/index.mdx
+++ b/build/index.mdx
@@ -39,6 +39,28 @@ You probably **don't** want this (yet) if you:
 - want to run mods that require a runtime source that is not in the platform base image catalog yet
 - expect free tier with persistent always-on servers — Grounds auto-pauses idle dev clusters after a few hours
 
+## Internal developer path
+
+If you work on Grounds plugins or platform-adjacent repos, start here:
+
+<CardGroup cols={2}>
+<Card title="Internal quickstart" icon="rocket" href="/build/quickstart">
+  Set up a local workspace, authenticate the CLI, and push with local plugin overrides.
+</Card>
+
+<Card title="Local plugin workspaces" icon="folder-tree" href="/build/local-plugin-workspaces">
+  Map independent plugin repos into `grounds push --local` and `--with-local`.
+</Card>
+
+<Card title="Multi-plugin stacks" icon="layer-group" href="/build/multi-plugin-stacks">
+  Test Paper, Velocity, or gamemode stacks with multiple plugins in one push.
+</Card>
+
+<Card title="Debug pushes" icon="bug" href="/build/debug-pushes">
+  Work through local build, upload, Forge build, and deployment failures.
+</Card>
+</CardGroup>
+
 ## Get started in five minutes
 
 <Steps>
@@ -47,7 +69,7 @@ You probably **don't** want this (yet) if you:
   brew install --cask groundsgg/tap/grounds
   ```
 
-  Linux/Windows + scripts: see [Quickstart → Install](/build/quickstart#install-the-cli).
+  Linux/Windows + scripts: see [Quickstart → Install](/build/quickstart#2-install-and-sign-in-with-the-cli).
 </Step>
 
 <Step title="Sign in">

--- a/build/local-development.mdx
+++ b/build/local-development.mdx
@@ -39,6 +39,13 @@ You'll need a cloud `dev` push when:
 
 The mental model: `groundsTestLocal` answers *"does my plugin work?"*; `grounds push --target=dev` answers *"does my plugin work on the platform?"*.
 
+<Tip>
+When you need multiple independent plugin repositories on the same server, use
+[Local plugin workspaces](/build/local-plugin-workspaces) and
+[Multi-plugin stacks](/build/multi-plugin-stacks). `groundsTestLocal` is best
+for one plugin in one local Paper or Velocity server.
+</Tip>
+
 ## A typical day
 
 ```bash

--- a/build/local-plugin-workspaces.mdx
+++ b/build/local-plugin-workspaces.mdx
@@ -1,0 +1,178 @@
+---
+title: "Work with local plugin workspaces"
+description: "Override release plugin sources with local builds from independent repositories."
+---
+
+Local plugin workspaces let you keep `grounds.yaml` pointed at release plugin
+sources while opting into local builds for a single push. Use this workflow when
+your app lives in one repository and the plugin dependencies you are changing
+live in sibling repositories.
+
+<Tip>
+Local overrides are machine-local. They do not change the manifest, and they
+only apply when you pass `--local` or `--with-local`.
+</Tip>
+
+## Repository layout
+
+Use the internal sample workspace as the reference shape:
+
+```text
+~/grounds/
+  sample-plugin-workspace/
+    app/
+      grounds.yaml
+  plugin-agones/
+  plugin-player/
+```
+
+Run `grounds push` from `~/grounds/sample-plugin-workspace/app`. Keep
+`plugin-agones` and `plugin-player` beside the app repository so the CLI can map
+release plugin IDs to the local repositories on your machine.
+
+Your manifest stays portable:
+
+```yaml grounds.yaml
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+The `id` and `variant` fields are the matching keys. The `source` fields remain
+the default release sources for teammates, CI, and any push that does not opt
+into local overrides.
+
+## Scan for repositories
+
+Start by asking the CLI to discover plugin repositories under `~/grounds`:
+
+```bash
+grounds workspace scan ~/grounds
+```
+
+Without `--yes`, the CLI prints the mappings it found and asks before writing
+them. Once the proposed mappings look right, write them immediately:
+
+```bash
+grounds workspace scan ~/grounds --yes
+```
+
+<Note>
+Scan does not replace existing mappings. If you already pinned custom Velocity
+artifacts or build commands, those entries stay in place.
+</Note>
+
+## Pin exact Velocity artifacts
+
+For Velocity plugin repositories, add explicit mappings so the push uses the
+deployable shadow JAR from each repository:
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace add plugin-player ~/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+```
+
+The artifact path is relative to the plugin repository. The build command runs
+inside that repository before the artifact is resolved.
+
+## Inspect mappings
+
+List the workspace entries before pushing:
+
+```bash
+grounds workspace list
+```
+
+Use `doctor` when a mapping does not behave as expected:
+
+```bash
+grounds workspace doctor
+```
+
+`workspace list` shows each plugin ID, variant, enabled state, repository path,
+artifact path, and build command. `workspace doctor` checks whether configured
+paths exist and reports missing local repositories.
+
+## Push one local override
+
+From `~/grounds/sample-plugin-workspace/app`, override only
+`plugin-agones` for this push:
+
+```bash
+grounds push --target=dev --local plugin-agones
+```
+
+The app manifest still reads both plugins from release sources, but the CLI
+replaces `plugin-agones` with the local Velocity artifact for this one push.
+
+You can pass multiple local plugin IDs as a comma-separated value:
+
+```bash
+grounds push --target=dev --local plugin-agones,plugin-player
+```
+
+You can also repeat `--local`:
+
+```bash
+grounds push --target=dev --local plugin-agones --local plugin-player
+```
+
+## Push every enabled local override
+
+When every enabled workspace mapping should replace its matching manifest entry,
+use `--with-local`:
+
+```bash
+grounds push --target=dev --with-local
+```
+
+This is the usual internal loop for the sample workspace after both Velocity
+artifacts are pinned. Disabled mappings are ignored.
+
+## Disable a mapping temporarily
+
+Disable `plugin-player` when you want `--with-local` to keep using the release
+source for that plugin:
+
+```bash
+grounds workspace enable plugin-player velocity --disable
+```
+
+Enable it again when you want the local Velocity artifact back in the push:
+
+```bash
+grounds workspace enable plugin-player velocity
+```
+
+## Config location
+
+Workspace mappings are stored in the CLI config directory as `workspace.yaml`.
+By default, that is:
+
+| OS | Default workspace file |
+| --- | --- |
+| Linux | `~/.config/grounds/workspace.yaml` |
+| macOS | `~/Library/Application Support/grounds/workspace.yaml` |
+| Windows | `%APPDATA%\grounds\workspace.yaml` |
+
+The global `--config <dir>` flag and `GROUNDS_CONFIG_DIR` environment variable
+move this file together with the rest of the CLI config. See
+[Configuration](/build/cli/configuration) for the full config directory rules.
+
+## Reference
+
+- [Workspace CLI reference](/build/cli/workspace)
+- [Push CLI reference](/build/cli/push)
+- [Configuration reference](/build/cli/configuration)
+- [Build multi-plugin stacks](/build/multi-plugin-stacks)

--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -83,20 +83,49 @@ When to set it explicitly:
 
 A list of 2–10 plugin sources bundled into a single Paper / Velocity / gamemode server. Useful when you want to test plugin interaction (economy + chat + teams) on one running instance instead of pushing each plugin as its own server.
 
+For the internal workflow that uses these fields with local overrides, see
+[Test multi-plugin stacks](/build/multi-plugin-stacks).
+
 A working end-to-end example lives at [groundsgg/multi-plugin-sample](https://github.com/groundsgg/multi-plugin-sample) — two trivial Paper plugins bundled via `:gradle-project` refs. Clone, run `./gradlew groundsPush`, see both plugins boot on one server.
 
-Each entry is one of four source kinds, distinguished by prefix:
+For team workflows, prefer structured entries with `id`, optional `variant`,
+and `source`:
+
+```yaml
+name: velocity-stack
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+`source` is the portable default used by plain `grounds push`. `id` and
+`variant` let the CLI match the entry to a local
+[workspace override](/build/cli/workspace) when you pass `--local` or
+`--with-local`.
+
+Each `source` is one of four source kinds, distinguished by prefix:
 
 ```yaml
 name: combo
 type: plugin-paper
 baseImage: paper
 plugins:
-  - modules/economy/build/libs/economy.jar           # local (relative)
-  - /opt/jars/legacy.jar                             # local (absolute)
-  - :chat                                            # Gradle project
-  - github:groundsgg/plugin-teams@v0.3.0             # GitHub release, first .jar asset
-  - github:groundsgg/plugin-shop@v1.4.2:shop-all.jar # GitHub release, named asset
+  - id: economy
+    source: modules/economy/build/libs/economy.jar           # local (relative)
+  - id: legacy
+    source: /opt/jars/legacy.jar                             # local (absolute)
+  - id: chat
+    source: :chat                                            # Gradle project
+  - id: teams
+    source: github:groundsgg/plugin-teams@v0.3.0             # GitHub release, first .jar asset
+  - id: shop
+    source: github:groundsgg/plugin-shop@v1.4.2:shop-all.jar # GitHub release, named asset
 ```
 
 | Kind | Form | Resolved by |
@@ -106,6 +135,12 @@ plugins:
 | GitHub release | `github:<owner>/<repo>@<tag>[:<asset>]` | `groundsPush` downloads from the GitHub Releases API into `~/.gradle/caches/grounds-push/` |
 
 The Gradle plugin packs all resolved JARs into a `tar.gz` and forge unpacks them into `/app/plugins/` in manifest order (a numeric prefix preserves load order, since Paper's `pluginsFolder` scan is filesystem-ordered).
+
+<Tip>
+Keep local filesystem paths out of shared manifests when multiple developers
+work in separate repositories. Put release sources in `grounds.yaml` and put
+machine-specific paths in `workspace.yaml` instead.
+</Tip>
 
 #### GitHub source rules
 
@@ -121,7 +156,7 @@ Cache key is `<owner>-<repo>-<tag>-<asset>.jar`. Because tags are immutable pins
 
 - Mutually exclusive with `jar:` — pick one shape per manifest.
 - Forbidden for `type: service` (services have a single-jar `ENTRYPOINT`; multi-plugin has no meaningful semantics there).
-- 2 minimum (single-plugin uses `jar:`), 10 maximum, 50 MB total upload after resolution.
+- 2 minimum (single-plugin uses `jar:`), 10 maximum, 100 MB total upload after resolution.
 - For Gradle project refs the subproject must apply a Jar-producing plugin (`java`, `com.gradleup.shadow`, etc.). `groundsPush` discovers `shadowJar` first, then falls back to `jar`.
 - Absolute local paths still work but log a "non-portable manifest" warning, because CI won't see your machine's filesystem.
 

--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -109,7 +109,7 @@ plugins:
 [workspace override](/build/cli/workspace) when you pass `--local` or
 `--with-local`.
 
-Each `source` is one of four source kinds, distinguished by prefix:
+Each `source` is one of three source kinds, distinguished by prefix:
 
 ```yaml
 name: combo

--- a/build/multi-plugin-stacks.mdx
+++ b/build/multi-plugin-stacks.mdx
@@ -1,0 +1,106 @@
+---
+title: "Test multi-plugin stacks"
+description: "Bundle multiple Paper, Velocity, or gamemode plugins into one Grounds push."
+---
+
+Multi-plugin stacks let you push several plugin JARs onto one Minecraft workload so you can test integration behavior in the same runtime that players connect to.
+
+## When to use `plugins:`
+
+Use `plugins:` when the thing you need to validate depends on more than one plugin being present in the same Paper, Velocity, or gamemode server.
+
+Common cases:
+
+- A Velocity proxy plugin depends on another proxy plugin being installed.
+- A Paper plugin needs an economy, chat, teams, or permissions plugin in the same server.
+- A gamemode needs its runtime plugin plus support plugins in the same Agones-managed workload.
+- You want a shared release-default manifest that teammates can override with local plugin builds when debugging cross-plugin behavior.
+
+For a single plugin push, keep using `jar:` instead.
+
+## Structured entries
+
+Use structured plugin entries so release sources, local overrides, and push output all refer to the same stable plugin keys.
+
+```yaml grounds.yaml
+name: sample-velocity-plugins
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+`id` is the stable key used for workspace overrides and source reporting. Keep it short, lowercase, and consistent across manifests and workspace configuration.
+
+`variant` identifies which artifact variant the stack expects. Use `paper`, `velocity`, or `minestom` depending on the plugin repository and workload.
+
+`source` is the portable default for plain `grounds push`. It should be something another developer or CI runner can resolve without your local filesystem.
+
+## Release defaults, local overrides
+
+Keep release sources in `grounds.yaml` and put machine-specific paths in your local workspace config. That gives the team a reproducible default while still allowing local plugin replacement during development.
+
+Plain pushes use the release sources:
+
+```bash
+grounds push --target=dev
+```
+
+Push with every enabled local workspace override:
+
+```bash
+grounds push --target=dev --with-local
+```
+
+Push with selected local overrides:
+
+```bash
+grounds push --target=dev --local plugin-agones
+grounds push --target=dev --local plugin-agones,plugin-player
+```
+
+When you pass `--with-local`, the CLI replaces enabled workspace entries for that push before Gradle uploads the bundle. Entries without a matching enabled workspace mapping continue to use their manifest `source`.
+
+See [local plugin workspaces](/build/local-plugin-workspaces) for scanning repositories, adding mappings, enabling variants, and checking which source each plugin will use.
+
+## Supported source forms
+
+Each `source` resolves to one JAR before upload.
+
+| Source form | Example | Use when |
+| --- | --- | --- |
+| Relative local path | `modules/economy/build/libs/economy.jar` | The manifest is only used inside one repository layout. |
+| Absolute local path | `/opt/jars/legacy.jar` | You need a local-only escape hatch. Prefer workspace overrides for shared work. |
+| Gradle project | `:chat` or `:plugins:chat` | The plugin is built by another subproject in the same Gradle build. |
+| GitHub release | `github:groundsgg/plugin-player@v0.1.0` | You want a portable release default. |
+| GitHub release asset | `github:groundsgg/plugin-shop@v1.4.2:shop-all.jar` | A release has more than one JAR asset and you need a specific one. |
+
+The full manifest reference for source validation, GitHub release rules, and field behavior is in [`plugins`](/build/manifest#plugins-optional).
+
+## Upload shape
+
+`groundsPush` resolves every plugin entry to a JAR, packs the resolved files into one `tar.gz` bundle, and uploads that bundle as the push artifact. Forge unpacks the bundle into `/app/plugins/` in manifest order.
+
+The bundle preserves load order with numeric prefixes because Paper and Velocity scan plugin directories from the filesystem. Put dependency plugins before the plugins that need them.
+
+The Gradle task reference has the lower-level upload details in [Multi-plugin bundles](/build/gradle-plugin/groundsPush#multi-plugin-bundles).
+
+## Limits
+
+- `plugins:` and `jar:` are mutually exclusive. Pick one artifact shape per manifest.
+- `plugins:` requires 2 to 10 entries.
+- `plugins:` is supported for `plugin-paper`, `plugin-velocity`, and `gamemode`.
+- `plugins:` is not supported for `service`.
+- The total resolved upload is capped at 100 MB.
+- Local paths work, but they are not portable across machines or CI.
+
+## Next steps
+
+- Use [local plugin workspaces](/build/local-plugin-workspaces) when you need to replace release entries with local builds.
+- Use the [`plugins` manifest reference](/build/manifest#plugins-optional) for exact schema and validation rules.
+- Use [`groundsPush` multi-plugin bundles](/build/gradle-plugin/groundsPush#multi-plugin-bundles) for Gradle task behavior and upload details.

--- a/build/quickstart.mdx
+++ b/build/quickstart.mdx
@@ -30,10 +30,12 @@ mkdir -p ~/grounds
 cd ~/grounds
 git clone git@github.com:groundsgg/plugin-agones.git
 git clone git@github.com:groundsgg/plugin-player.git
+mkdir -p sample-plugin-workspace/app
 ```
 
-Clone or create your app repo under the same parent. The examples below use
-`~/grounds/sample-plugin-workspace/app`.
+This creates the app workspace used by later commands at
+`~/grounds/sample-plugin-workspace/app`. If you already have an app repo, clone
+or move it under the same parent and use that path instead.
 
 ## 2. Install and sign in with the CLI
 

--- a/build/quickstart.mdx
+++ b/build/quickstart.mdx
@@ -1,17 +1,43 @@
 ---
-title: "Quickstart"
-description: "From zero to a public Minecraft server URL in five minutes."
+title: "Internal developer quickstart"
+description: "Set up an internal Grounds workspace, push a plugin, and test local plugin overrides."
 ---
 
-This guide walks through your first push. By the end you'll have a Paper plugin running on managed infrastructure, reachable at a public `*.mc.grnds.io` address.
+This guide starts from a fresh internal development workspace. By the end,
+you'll have the CLI authenticated, Gradle ready to resolve `grounds-push`, and
+a Velocity stack pushed with local `plugin-agones` and `plugin-player` builds.
+
+<Note>
+Examples use `~/grounds` as the parent directory. Use any directory you prefer,
+but keep the app repo and plugin repos under one parent so workspace scans are
+predictable.
+</Note>
 
 ## Prerequisites
 
-- A Grounds Account (talk to your org admin if you don't have one yet)
-- Java 21+ and Gradle (a Gradle wrapper in your project is fine)
-- macOS, Linux, or Windows (WSL2 works)
+- A Grounds Account.
+- Java 21+.
+- A Gradle wrapper in each plugin repository.
+- Git access to the internal repositories you work on.
+- A GitHub token with `read:packages` for resolving `gg.grounds.push` from GitHub Packages.
 
-## Install the CLI
+## 1. Create your workspace directory
+
+Keep the app repo and plugin repos under one parent directory:
+
+```bash
+mkdir -p ~/grounds
+cd ~/grounds
+git clone git@github.com:groundsgg/plugin-agones.git
+git clone git@github.com:groundsgg/plugin-player.git
+```
+
+Clone or create your app repo under the same parent. The examples below use
+`~/grounds/sample-plugin-workspace/app`.
+
+## 2. Install and sign in with the CLI
+
+Install the CLI for your operating system:
 
 <Tabs>
 <Tab title="macOS / Linux (Homebrew)">
@@ -35,13 +61,13 @@ scoop install grounds
 </Tab>
 </Tabs>
 
-## Sign in
+Sign in with your Grounds Account:
 
 ```bash
 grounds login
 ```
 
-The CLI opens your browser to Grounds Account. Sign in with your Grounds Account and approve the device code shown in the terminal — the CLI persists tokens in your OS keyring and you only need to repeat this when the session expires (usually weekly).
+The CLI opens your browser to Grounds Account. Sign in with your Grounds Account and approve the device code shown in the terminal. The CLI stores credentials in its config directory and you only need to repeat this when the session expires.
 
 Verify with:
 
@@ -49,94 +75,139 @@ Verify with:
 grounds doctor
 ```
 
-You should see green checks on `auth`, `api`, and `gradle wrapper` (if run from a project root).
+You should see green checks on `auth`, `api`, and `gradle wrapper` when run
+from a project root.
 
-## Set up the Gradle plugin
+## 3. Configure GitHub Packages for Gradle
 
-Grounds builds straight from Gradle. Add the plugin to your `build.gradle.kts`:
-
-```kotlin
-plugins {
-    `java-library`
-    id("gg.grounds.push") version "0.x" // see Releases for current
-}
-
-groundsPush {
-    // Reads ~/.config/grounds/credentials.json by default; no extra config needed.
-}
-
-dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
-}
-```
-
-Then create a `grounds.yaml` next to `build.gradle.kts`:
-
-```yaml
-name: my-plugin
-type: plugin-paper
-baseImage: paper
-jar: build/libs/my-plugin-0.1.0.jar
-```
-
-<Note>
-The `baseImage` field selects a catalog source key. `paper` means "use the current stable Paper runtime from the platform base image catalog." See [Base images](/build/concepts/base-images) for how versions are synced and promoted.
-</Note>
-
-## Your first push
+Internal Gradle builds resolve `gg.grounds.push` from GitHub Packages. Export
+credentials before running Gradle or `grounds push`:
 
 ```bash
+export GITHUB_ACTOR=<github-user>
+export GITHUB_TOKEN=<token-with-read-packages>
+```
+
+Your plugin repos can also read these values from your shell, Gradle properties,
+or your CI environment. Do not commit tokens to a repository.
+
+## 4. Check the app manifest
+
+The app manifest should keep shared release sources. Local workspace mappings
+replace those sources only for your push.
+
+Use this canonical sample manifest in `~/grounds/sample-plugin-workspace/app/grounds.yaml`:
+
+```yaml grounds.yaml
+name: sample-velocity-plugins
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+See the [manifest reference](/build/manifest) for exact field rules and supported
+workload shapes.
+
+## 5. Understand the release-source push
+
+Plain `grounds push` uses the release sources from `grounds.yaml`:
+
+```bash
+cd ~/grounds/sample-plugin-workspace/app
 grounds push --target=dev
 ```
 
-What happens:
+Use this path when the referenced GitHub releases publish `.jar` assets. If a
+release has no JAR asset yet, the push fails during source resolution; continue
+with local workspace mappings for active development.
 
-1. The Gradle plugin assembles your JAR and uploads it + the manifest to the Grounds API.
+When release sources are available, the push flow is:
+
+1. The Gradle plugin assembles the configured artifacts and uploads them with the manifest to the Grounds API.
 2. **Forge** runs a Kaniko build inside the cluster, pushes the resulting OCI image to the internal registry, and signs it with cosign.
-3. Forge applies a Deployment + Service to your personal namespace (`user-<your-handle>`).
+3. Forge applies the workload to your personal namespace (`user-<your-handle>`).
 4. Once the pod is Ready, the CLI prints the public URL.
 
-Output looks like:
+Connect from any Minecraft client using that address. The first connection
+cold-starts the server; after that it stays warm until idle.
 
-```
-✔ Build complete (image sha256:abc…)
-✔ Deploy ready
-  → minecraft://my-plugin-yourname.mc.grnds.io
-```
+## 6. Add local workspace mappings
 
-Connect from any Minecraft client using that address. The first connection cold-starts the server (~15s); after that it stays warm until idle.
-
-## Ephemeral preview env
-
-For sharing a build with playtesters without polluting your dev environment:
+Map each manifest plugin ID to the local repository, build command, and artifact
+that should replace the release source during local override pushes:
 
 ```bash
-grounds push --target=staging
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace add plugin-player ~/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace list
+grounds workspace doctor
 ```
 
-This creates a fresh `preview-<id>` namespace with a 7-day TTL. Hostname pattern: `<name>-pr<id>.mc.grnds.io`. Grounds garbage-collects the env automatically once the TTL expires — pin it to keep it longer:
+`grounds workspace doctor` checks that configured repository paths exist.
+
+## 7. Push with local plugin overrides
+
+Run a dev push with every enabled workspace mapping applied:
 
 ```bash
-grounds preview list           # find the id
-grounds preview pin <id>       # opt out of auto-cleanup
+grounds push --target=dev --with-local
+```
+
+<Note>
+The shared `grounds.yaml` still points at release sources. `--with-local`
+rewrites enabled workspace entries for this push only.
+</Note>
+
+## 8. Inspect the result
+
+Use the CLI output, Portal, and server logs to confirm the pushed stack is using
+your local builds. For a shareable preview of the same local override set
+without replacing your dev deployment, push to staging with `--with-local`:
+
+```bash
+grounds push --target=staging --with-local
+```
+
+This creates a fresh `preview-<id>` namespace with a 7-day TTL. Hostname pattern:
+`<name>-pr<id>.mc.grnds.io`. Grounds garbage-collects the env automatically once
+the TTL expires. See [Share staging previews](/build/share-staging-previews) for
+the full preview workflow, including pinning previews:
+
+```bash
+grounds preview list
+grounds preview pin <id>
 ```
 
 ## Next steps
 
 <CardGroup cols={2}>
-<Card title="CLI reference" icon="terminal" href="/build/cli">
-  Every subcommand and flag.
+<Card title="Local plugin workspaces" icon="folder-tree" href="/build/local-plugin-workspaces">
+  Map independent plugin repos into `grounds push --local` and `--with-local`.
 </Card>
 
-<Card title="Concepts" icon="book" href="/build/concepts">
-  Projects, dev clusters, preview envs — what they are and how they relate.
+<Card title="Multi-plugin stacks" icon="layer-group" href="/build/multi-plugin-stacks">
+  Test Paper, Velocity, or gamemode stacks with multiple plugins in one push.
 </Card>
 
-<Card title="Troubleshooting" icon="bug" href="/build/troubleshooting">
-  Common errors and how to fix them.
+<Card title="Debug pushes" icon="bug" href="/build/debug-pushes">
+  Work through local build, upload, Forge build, and deployment failures.
 </Card>
 
-<Card title="API reference" icon="code" href="/reference/apis">
-  Forge HTTP API for custom integrations.
+<Card title="Manifest reference" icon="file-code" href="/build/manifest">
+  Check fields, source formats, and workload shapes.
 </Card>
 </CardGroup>

--- a/build/share-staging-previews.mdx
+++ b/build/share-staging-previews.mdx
@@ -1,0 +1,76 @@
+---
+title: "Share staging previews"
+description: "Push a build to staging, share it with teammates, and manage preview lifetime."
+---
+
+Use staging when you need a real cluster preview that teammates, reviewers, or
+stakeholders can inspect without running your workspace locally.
+
+## Push to staging
+
+Push the current manifest to staging:
+
+```bash
+grounds push --target=staging
+```
+
+Every staging push creates a preview environment with its own namespace and
+public URL. The push output includes the preview link when provisioning
+completes.
+
+For the full push command reference, see [grounds push](/build/cli/push).
+
+## When to use staging
+
+Use staging for:
+
+- Reviewing a plugin or service in an environment that matches the shared
+  platform path.
+- Sharing a build with teammates who do not have your local workspace.
+- Running a demo or smoke test against a real preview URL.
+- Validating behavior that depends on platform networking, ingress, or runtime
+  configuration.
+
+For fast inner-loop checks on your machine, use local development instead of a
+staging preview.
+
+## List previews
+
+List active previews for the current project:
+
+```bash
+grounds preview list
+```
+
+Use the list to find the preview ID, status, expiry, pin state, and URL before
+sharing the build or changing its lifetime.
+
+## Pin a preview
+
+Pin a preview when a demo, review, or test run needs to stay available past the
+normal preview cleanup window:
+
+```bash
+grounds preview pin <preview-id>
+```
+
+Unpin it when the review is finished so the cleanup process can remove it:
+
+```bash
+grounds preview unpin <preview-id>
+```
+
+Pin sparingly. Pinned previews consume cluster resources until they are unpinned
+or deleted.
+
+## Inspect in Portal
+
+Open the project in Portal and use the **Previews** tab to inspect preview
+status, expiry, URL, and pin state. Portal exposes the same preview lifetime
+operations as the CLI, so use whichever surface fits the review flow.
+
+## Reference
+
+- [grounds preview](/build/cli/preview)
+- [Preview environments](/build/concepts/preview-environments)
+- [grounds push](/build/cli/push)

--- a/build/troubleshooting.mdx
+++ b/build/troubleshooting.mdx
@@ -3,6 +3,9 @@ title: "Troubleshooting"
 description: "Symptoms you'll hit, and what to check first."
 ---
 
+For a layer-by-layer debugging workflow, start with
+[Debug pushes and deployments](/build/debug-pushes).
+
 ## CLI
 
 ### `not logged in`

--- a/docs.json
+++ b/docs.json
@@ -23,6 +23,16 @@
           "build/index",
           "build/quickstart",
           {
+            "group": "Workflows",
+            "pages": [
+              "build/local-development",
+              "build/local-plugin-workspaces",
+              "build/multi-plugin-stacks",
+              "build/share-staging-previews",
+              "build/debug-pushes"
+            ]
+          },
+          {
             "group": "Concepts",
             "pages": [
               "build/concepts/projects-and-teams",
@@ -33,39 +43,44 @@
             ]
           },
           {
-            "group": "CLI",
+            "group": "Reference",
             "pages": [
-              "build/cli/installation",
-              "build/cli/auth",
-              "build/cli/push",
-              "build/cli/preview",
-              "build/cli/configuration"
+              "build/manifest",
+              {
+                "group": "CLI",
+                "pages": [
+                  "build/cli/installation",
+                  "build/cli/auth",
+                  "build/cli/push",
+                  "build/cli/workspace",
+                  "build/cli/preview",
+                  "build/cli/configuration"
+                ]
+              },
+              {
+                "group": "Gradle plugin",
+                "pages": [
+                  "build/gradle-plugin/setup",
+                  "build/gradle-plugin/groundsPush",
+                  "build/gradle-plugin/groundsPushRetry",
+                  "build/gradle-plugin/groundsTestLocal"
+                ]
+              },
+              "build/ci-tokens",
+              {
+                "group": "Portal",
+                "pages": [
+                  "build/portal/index",
+                  "build/portal/control-center-access",
+                  "build/portal/control-center-step-up"
+                ]
+              },
+              "build/observability"
             ]
           },
-          "build/manifest",
-          {
-            "group": "Gradle plugin",
-            "pages": [
-              "build/gradle-plugin/setup",
-              "build/gradle-plugin/groundsPush",
-              "build/gradle-plugin/groundsPushRetry",
-              "build/gradle-plugin/groundsTestLocal"
-            ]
-          },
-          "build/ci-tokens",
-          {
-            "group": "Portal",
-            "pages": [
-              "build/portal/index",
-              "build/portal/control-center-access",
-              "build/portal/control-center-step-up"
-            ]
-          },
-          "build/local-development",
-          "build/observability",
           "build/troubleshooting",
           {
-            "group": "Internal — Grounds engineers only",
+            "group": "Internal test environment",
             "pages": [
               "build/test-environment/index",
               "build/test-environment/bundle-reference"

--- a/docs/superpowers/plans/2026-05-14-build-docs-developer-journey.md
+++ b/docs/superpowers/plans/2026-05-14-build-docs-developer-journey.md
@@ -1,0 +1,844 @@
+# Build Docs Developer Journey Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure the Build docs around the internal developer journey while preserving all current Build information.
+
+**Architecture:** The Build section becomes journey-first in navigation, with short workflow pages for developer tasks and existing detailed pages moved under Reference. Existing URLs are preserved where practical; new pages compose and link to existing reference pages instead of duplicating flag and field tables.
+
+**Tech Stack:** Mintlify MDX docs, `docs.json` navigation, shell validation with `mintlify validate`, `git diff --check`, and `rg`.
+
+---
+
+## Current Branch Context
+
+This plan assumes work continues in `/home/lukas/grounds/docs` on branch:
+
+```bash
+feat/document-local-plugin-overrides
+```
+
+The branch already contains:
+
+- committed design spec: `docs/superpowers/specs/2026-05-14-build-docs-developer-journey-design.md`
+- uncommitted local override docs changes:
+  - `build/cli/workspace.mdx`
+  - `build/cli/configuration.mdx`
+  - `build/cli/push.mdx`
+  - `build/gradle-plugin/groundsPush.mdx`
+  - `build/gradle-plugin/setup.mdx`
+  - `build/manifest.mdx`
+  - `docs.json`
+
+Treat those uncommitted changes as in-scope. Do not revert them.
+
+---
+
+## Target File Structure
+
+### Create
+
+- `build/local-plugin-workspaces.mdx`  
+  Journey page for local workspace overrides with the real internal Velocity sample.
+
+- `build/multi-plugin-stacks.mdx`  
+  Journey page for multi-plugin Paper/Velocity/gamemode bundles.
+
+- `build/share-staging-previews.mdx`  
+  Journey page for staging previews and sharing builds.
+
+- `build/debug-pushes.mdx`  
+  Journey page for diagnosing failed pushes and local override issues.
+
+### Modify
+
+- `docs.json`  
+  Reorder Build navigation into Overview, Quickstart, Workflows, Concepts, Reference, Troubleshooting, Internal test environment.
+
+- `build/index.mdx`  
+  Keep current overview/value proposition, add internal developer journey entry points.
+
+- `build/quickstart.mdx`  
+  Rewrite as internal developer quickstart from fresh workspace to first local override push.
+
+- `build/local-development.mdx`  
+  Keep existing local `groundsTestLocal` information and add links to workspace/multi-plugin workflows.
+
+- `build/cli/workspace.mdx`  
+  Keep as CLI reference for exact workspace commands. Ensure it links back to the journey page.
+
+- `build/cli/push.mdx`  
+  Keep exact push flag reference. Ensure it links to workflow pages.
+
+- `build/cli/preview.mdx`  
+  Keep exact preview command reference. Ensure it links to staging preview workflow.
+
+- `build/manifest.mdx`  
+  Keep exact manifest schema/reference. Ensure structured `plugins:` and 100 MB cap are documented.
+
+- `build/gradle-plugin/groundsPush.mdx`  
+  Keep exact Gradle task reference. Ensure multi-plugin bundle behavior links to workflow page.
+
+- `build/troubleshooting.mdx`  
+  Keep detailed troubleshooting information and add links to debug workflow.
+
+---
+
+## Task 1: Confirm Baseline And Preserve Current Work
+
+**Files:**
+- Inspect: `docs.json`
+- Inspect: `build/cli/workspace.mdx`
+- Inspect: `build/quickstart.mdx`
+- Inspect: `build/index.mdx`
+
+- [ ] **Step 1: Check branch and dirty state**
+
+Run:
+
+```bash
+cd /home/lukas/grounds/docs
+git status --short --branch
+```
+
+Expected:
+
+```text
+## feat/document-local-plugin-overrides
+ M build/cli/configuration.mdx
+ M build/cli/push.mdx
+ M build/gradle-plugin/groundsPush.mdx
+ M build/gradle-plugin/setup.mdx
+ M build/manifest.mdx
+ M docs.json
+untracked build/cli/workspace.mdx
+untracked docs/superpowers/plans/2026-05-14-build-docs-developer-journey.md
+```
+
+Extra files are acceptable only if they are docs work from this branch. If unrelated files appear, stop and ask before staging or editing them.
+
+- [ ] **Step 2: Review current navigation**
+
+Run:
+
+```bash
+sed -n '1,180p' docs.json
+```
+
+Confirm the current Build navigation still contains all existing Build pages before restructuring.
+
+- [ ] **Step 3: Review the current workspace reference page**
+
+Run:
+
+```bash
+sed -n '1,260p' build/cli/workspace.mdx
+```
+
+Confirm the page has frontmatter and covers `workspace scan`, `add`, `list`, `enable`, `doctor`, `--local`, and `--with-local`.
+
+---
+
+## Task 2: Rewrite Build Navigation
+
+**Files:**
+- Modify: `docs.json`
+
+- [ ] **Step 1: Replace only the Build tab `pages` array**
+
+Edit the Build tab in `docs.json` so its `"pages"` array is exactly:
+
+```json
+[
+  "build/index",
+  "build/quickstart",
+  {
+    "group": "Workflows",
+    "pages": [
+      "build/local-development",
+      "build/local-plugin-workspaces",
+      "build/multi-plugin-stacks",
+      "build/share-staging-previews",
+      "build/debug-pushes"
+    ]
+  },
+  {
+    "group": "Concepts",
+    "pages": [
+      "build/concepts/projects-and-teams",
+      "build/concepts/targets",
+      "build/concepts/pushes",
+      "build/concepts/base-images",
+      "build/concepts/preview-environments"
+    ]
+  },
+  {
+    "group": "Reference",
+    "pages": [
+      "build/manifest",
+      {
+        "group": "CLI",
+        "pages": [
+          "build/cli/installation",
+          "build/cli/auth",
+          "build/cli/push",
+          "build/cli/workspace",
+          "build/cli/preview",
+          "build/cli/configuration"
+        ]
+      },
+      {
+        "group": "Gradle plugin",
+        "pages": [
+          "build/gradle-plugin/setup",
+          "build/gradle-plugin/groundsPush",
+          "build/gradle-plugin/groundsPushRetry",
+          "build/gradle-plugin/groundsTestLocal"
+        ]
+      },
+      "build/ci-tokens",
+      {
+        "group": "Portal",
+        "pages": [
+          "build/portal/index",
+          "build/portal/control-center-access",
+          "build/portal/control-center-step-up"
+        ]
+      },
+      "build/observability"
+    ]
+  },
+  "build/troubleshooting",
+  {
+    "group": "Internal test environment",
+    "pages": [
+      "build/test-environment/index",
+      "build/test-environment/bundle-reference"
+    ]
+  }
+]
+```
+
+Keep all other `docs.json` tabs unchanged.
+
+- [ ] **Step 2: Validate all Build pages are still referenced**
+
+Run:
+
+```bash
+find build -maxdepth 3 -type f -name '*.mdx' | sort
+```
+
+Compare every current Build page against `docs.json`. The only Build MDX pages that may be absent from navigation are pages that were already intentionally absent before this task. If a previously visible Build page disappeared from navigation, add it to the appropriate group.
+
+---
+
+## Task 3: Rewrite `build/quickstart.mdx` As Internal Developer Quickstart
+
+**Files:**
+- Modify: `build/quickstart.mdx`
+
+- [ ] **Step 1: Replace frontmatter**
+
+Use:
+
+```mdx
+---
+title: "Internal developer quickstart"
+description: "Set up an internal Grounds workspace, push a plugin, and test local plugin overrides."
+---
+```
+
+- [ ] **Step 2: Replace body with the internal journey**
+
+Use this structure:
+
+```mdx
+This guide starts from a fresh internal development workspace. By the end,
+you'll have the CLI authenticated, Gradle ready to resolve `grounds-push`, and
+a Velocity stack pushed with local `plugin-agones` and `plugin-player` builds.
+
+<Note>
+Examples use `~/grounds` as the parent directory. Use any directory you prefer,
+but keep the app repo and plugin repos under one parent so workspace scans are
+predictable.
+</Note>
+
+## Prerequisites
+
+- A Grounds Account.
+- Java 21+.
+- A Gradle wrapper in each plugin repository.
+- Git access to the internal repositories you work on.
+- A GitHub token with `read:packages` for resolving `gg.grounds.push` from GitHub Packages.
+```
+
+Then add sections with these exact headings:
+
+```mdx
+## 1. Create your workspace directory
+## 2. Install and sign in with the CLI
+## 3. Configure GitHub Packages for Gradle
+## 4. Check the app manifest
+## 5. Push with release sources
+## 6. Add local workspace mappings
+## 7. Push with local plugin overrides
+## 8. Inspect the result
+## Next steps
+```
+
+Include these commands and examples in the appropriate sections:
+
+```bash
+mkdir -p ~/grounds
+cd ~/grounds
+git clone git@github.com:groundsgg/plugin-agones.git
+git clone git@github.com:groundsgg/plugin-player.git
+grounds login
+grounds doctor
+```
+
+```bash
+export GITHUB_ACTOR=<github-user>
+export GITHUB_TOKEN=<token-with-read-packages>
+```
+
+```yaml grounds.yaml
+name: sample-velocity-plugins
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+```bash
+cd ~/grounds/sample-plugin-workspace/app
+grounds push --target=dev
+```
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace add plugin-player ~/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace list
+grounds workspace doctor
+grounds push --target=dev --with-local
+```
+
+Add a final `CardGroup` linking to:
+
+- `/build/local-plugin-workspaces`
+- `/build/multi-plugin-stacks`
+- `/build/debug-pushes`
+- `/build/manifest`
+
+- [ ] **Step 3: Preserve public first-push information**
+
+Confirm the rewritten quickstart still contains:
+
+- CLI install commands for Homebrew, curl, and Scoop.
+- `grounds login`.
+- `grounds doctor`.
+- first `grounds push --target=dev`.
+- staging path linked through `build/share-staging-previews.mdx`.
+
+---
+
+## Task 4: Create `build/local-plugin-workspaces.mdx`
+
+**Files:**
+- Create: `build/local-plugin-workspaces.mdx`
+- Modify: `build/cli/workspace.mdx`
+
+- [ ] **Step 1: Create journey page**
+
+Create `build/local-plugin-workspaces.mdx` with sections:
+
+```mdx
+---
+title: "Work with local plugin workspaces"
+description: "Override release plugin sources with local builds from independent repositories."
+---
+
+## Repository layout
+## Scan for repositories
+## Pin exact Velocity artifacts
+## Inspect mappings
+## Push one local override
+## Push every enabled local override
+## Disable a mapping temporarily
+## Config location
+## Reference
+```
+
+Use the canonical sample:
+
+```text
+~/grounds/
+  sample-plugin-workspace/
+    app/
+      grounds.yaml
+  plugin-agones/
+  plugin-player/
+```
+
+Include these commands:
+
+```bash
+grounds workspace scan ~/grounds
+grounds workspace scan ~/grounds --yes
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+grounds workspace add plugin-player ~/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+grounds workspace list
+grounds workspace doctor
+grounds push --target=dev --local plugin-agones
+grounds push --target=dev --local plugin-agones,plugin-player
+grounds push --target=dev --local plugin-agones --local plugin-player
+grounds push --target=dev --with-local
+grounds workspace enable plugin-player velocity --disable
+grounds workspace enable plugin-player velocity
+```
+
+Add reference links to:
+
+- `/build/cli/workspace`
+- `/build/cli/push`
+- `/build/cli/configuration`
+- `/build/multi-plugin-stacks`
+
+- [ ] **Step 2: Link reference page back to journey**
+
+In `build/cli/workspace.mdx`, after the opening paragraph, add:
+
+```mdx
+For the internal step-by-step workflow, start with
+[Work with local plugin workspaces](/build/local-plugin-workspaces).
+```
+
+---
+
+## Task 5: Create `build/multi-plugin-stacks.mdx`
+
+**Files:**
+- Create: `build/multi-plugin-stacks.mdx`
+- Modify: `build/manifest.mdx`
+- Modify: `build/gradle-plugin/groundsPush.mdx`
+
+- [ ] **Step 1: Create workflow page**
+
+Create `build/multi-plugin-stacks.mdx` with sections:
+
+```mdx
+---
+title: "Test multi-plugin stacks"
+description: "Bundle multiple Paper, Velocity, or gamemode plugins into one Grounds push."
+---
+
+## When to use `plugins:`
+## Structured entries
+## Release defaults, local overrides
+## Supported source forms
+## Upload shape
+## Limits
+## Next steps
+```
+
+Include the canonical `sample-velocity-plugins` manifest and explain:
+
+- `id` is the stable key for workspace overrides and source reporting.
+- `variant` identifies `paper`, `velocity`, or `minestom` variants.
+- `source` is the portable default for plain `grounds push`.
+- `grounds push --with-local` replaces enabled workspace entries for the push.
+- `plugins:` and `jar:` are mutually exclusive.
+- `plugins:` supports 2 to 10 entries.
+- total upload size is capped at 100 MB.
+
+- [ ] **Step 2: Add cross-link from manifest**
+
+In `build/manifest.mdx`, after the first paragraph under `### plugins`, add:
+
+```mdx
+For the internal workflow that uses these fields with local overrides, see
+[Test multi-plugin stacks](/build/multi-plugin-stacks).
+```
+
+- [ ] **Step 3: Add cross-link from Gradle task reference**
+
+In `build/gradle-plugin/groundsPush.mdx`, at the end of the `Multi-plugin bundles` section, add:
+
+```mdx
+For the developer workflow around this feature, see
+[Test multi-plugin stacks](/build/multi-plugin-stacks).
+```
+
+---
+
+## Task 6: Create `build/share-staging-previews.mdx`
+
+**Files:**
+- Create: `build/share-staging-previews.mdx`
+- Modify: `build/cli/preview.mdx`
+- Modify: `build/concepts/preview-environments.mdx`
+
+- [ ] **Step 1: Create workflow page**
+
+Create `build/share-staging-previews.mdx` with sections:
+
+```mdx
+---
+title: "Share staging previews"
+description: "Push a build to staging, share it with teammates, and manage preview lifetime."
+---
+
+## Push to staging
+## When to use staging
+## List previews
+## Pin a preview
+## Inspect in Portal
+## Reference
+```
+
+Include these commands:
+
+```bash
+grounds push --target=staging
+grounds preview list
+grounds preview pin <preview-id>
+grounds preview unpin <preview-id>
+```
+
+Link to:
+
+- `/build/cli/preview`
+- `/build/concepts/preview-environments`
+- `/build/cli/push`
+
+- [ ] **Step 2: Link CLI preview reference back to workflow**
+
+Near the top of `build/cli/preview.mdx`, add:
+
+```mdx
+For the developer workflow, see [Share staging previews](/build/share-staging-previews).
+```
+
+- [ ] **Step 3: Link concept page back to workflow**
+
+Near the top of `build/concepts/preview-environments.mdx`, add:
+
+```mdx
+For the step-by-step staging workflow, see
+[Share staging previews](/build/share-staging-previews).
+```
+
+---
+
+## Task 7: Create `build/debug-pushes.mdx`
+
+**Files:**
+- Create: `build/debug-pushes.mdx`
+- Modify: `build/troubleshooting.mdx`
+- Modify: `build/cli/push.mdx`
+
+- [ ] **Step 1: Create workflow page**
+
+Create `build/debug-pushes.mdx` with sections:
+
+```mdx
+---
+title: "Debug pushes and deployments"
+description: "Diagnose failed local builds, uploads, Forge builds, and deployments."
+---
+
+## 1. Read the CLI output
+## 2. Check local workspace mappings
+## 3. Check the source table
+## 4. Inspect Gradle directly
+## 5. Inspect Portal
+## 6. Tail deployment logs
+## 7. Retry transient failures
+## Reference
+```
+
+Include the diagnostic table:
+
+```mdx
+| Layer | Typical signal |
+| --- | --- |
+| Workspace resolution | `local workspace entry ... not found` |
+| Local build | Gradle failure from the dependency repo build command |
+| Upload | HTTP, auth, file size, or network error |
+| Forge build | `build_failed` |
+| Deploy | `deploy_failed`, pod scheduling, readiness, or crash loop |
+```
+
+Include these commands:
+
+```bash
+grounds workspace list
+grounds workspace doctor
+cd ~/grounds/plugin-agones
+./gradlew :velocity:shadowJar
+./gradlew groundsPush --target=dev --stacktrace
+grounds logs deployment <app-name>
+grounds push retry <push-id>
+```
+
+- [ ] **Step 2: Link troubleshooting page back to debug workflow**
+
+Near the top of `build/troubleshooting.mdx`, add:
+
+```mdx
+For a layer-by-layer debugging workflow, start with
+[Debug pushes and deployments](/build/debug-pushes).
+```
+
+- [ ] **Step 3: Link push reference back to debug workflow**
+
+In `build/cli/push.mdx`, near the `Exit codes` section, add:
+
+```mdx
+For a practical failure investigation flow, see
+[Debug pushes and deployments](/build/debug-pushes).
+```
+
+---
+
+## Task 8: Update Build Overview And Local Development Cross-links
+
+**Files:**
+- Modify: `build/index.mdx`
+- Modify: `build/local-development.mdx`
+
+- [ ] **Step 1: Add journey entry points to Build overview**
+
+In `build/index.mdx`, after the `Who this is for` section and before `Get started in five minutes`, add:
+
+```mdx
+## Internal developer path
+
+If you work on Grounds plugins or platform-adjacent repos, start here:
+
+<CardGroup cols={2}>
+<Card title="Internal quickstart" icon="rocket" href="/build/quickstart">
+  Set up a local workspace, authenticate the CLI, and push with local plugin overrides.
+</Card>
+
+<Card title="Local plugin workspaces" icon="folder-tree" href="/build/local-plugin-workspaces">
+  Map independent plugin repos into `grounds push --local` and `--with-local`.
+</Card>
+
+<Card title="Multi-plugin stacks" icon="layer-group" href="/build/multi-plugin-stacks">
+  Test Paper, Velocity, or gamemode stacks with multiple plugins in one push.
+</Card>
+
+<Card title="Debug pushes" icon="bug" href="/build/debug-pushes">
+  Work through local build, upload, Forge build, and deployment failures.
+</Card>
+</CardGroup>
+```
+
+- [ ] **Step 2: Keep existing overview content**
+
+Confirm `build/index.mdx` still contains:
+
+- `What you get`
+- `Who this is for`
+- install/login/push quick start steps or equivalent link
+- `What's under the hood`
+
+- [ ] **Step 3: Link local development to workspace workflow**
+
+In `build/local-development.mdx`, after `When local is not enough`, add:
+
+```mdx
+<Tip>
+When you need multiple independent plugin repositories on the same server, use
+[Local plugin workspaces](/build/local-plugin-workspaces) and
+[Multi-plugin stacks](/build/multi-plugin-stacks). `groundsTestLocal` is best
+for one plugin in one local Paper or Velocity server.
+</Tip>
+```
+
+---
+
+## Task 9: Review Reference Pages For Cross-links And Stale Claims
+
+**Files:**
+- Review/modify: `build/cli/configuration.mdx`
+- Review/modify: `build/cli/push.mdx`
+- Review/modify: `build/cli/workspace.mdx`
+- Review/modify: `build/gradle-plugin/setup.mdx`
+- Review/modify: `build/gradle-plugin/groundsPush.mdx`
+- Review/modify: `build/manifest.mdx`
+
+- [ ] **Step 1: Search for stale upload limits**
+
+Run:
+
+```bash
+rg -n "50 MB|50MB|100 MB|100MB" build
+```
+
+Expected:
+
+- No `50 MB` or `50MB` references for current push upload limits.
+- `100 MB` references are allowed in `build/manifest.mdx`, `build/gradle-plugin/groundsPush.mdx`, and workflow pages.
+
+- [ ] **Step 2: Search for stale plugin versions**
+
+Run:
+
+```bash
+rg -n 'gg\.grounds\.push"\) version "0\.5\.0|gg\.grounds\.push"\) version "0\.1\.0|version "0\.x"' build
+```
+
+Expected: no matches.
+
+- [ ] **Step 3: Search for broken old category links**
+
+Run:
+
+```bash
+rg -n 'href="/build/cli"|href="/build/concepts"|href="/build/gradle-plugin"' build
+```
+
+For any card/link pointing to a group path that does not exist as a page, replace it with the most specific existing page:
+
+- `/build/cli` -> `/build/cli/push` or `/build/cli/installation`
+- `/build/concepts` -> `/build/concepts/projects-and-teams`
+- `/build/gradle-plugin` -> `/build/gradle-plugin/setup`
+
+---
+
+## Task 10: Validate Mintlify And Navigation
+
+**Files:**
+- Validate: all docs
+
+- [ ] **Step 1: Run Mintlify validation**
+
+Run:
+
+```bash
+cd /home/lukas/grounds/docs
+mintlify validate
+```
+
+Expected:
+
+```text
+success build validation passed
+```
+
+- [ ] **Step 2: Run whitespace/conflict validation**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 3: Verify every new page is in navigation**
+
+Run:
+
+```bash
+rg -n "build/local-plugin-workspaces|build/multi-plugin-stacks|build/share-staging-previews|build/debug-pushes|build/cli/workspace" docs.json
+```
+
+Expected: all five paths appear.
+
+---
+
+## Task 11: Commit The Documentation Restructure
+
+**Files:**
+- Stage all intended docs changes from this plan.
+
+- [ ] **Step 1: Review final status**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --stat
+```
+
+Expected changed paths include only docs files touched by this plan.
+
+- [ ] **Step 2: Stage intended docs changes**
+
+Run:
+
+```bash
+git add docs.json build docs/superpowers/plans/2026-05-14-build-docs-developer-journey.md
+```
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git commit -m "docs: restructure build developer journey"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Task 12: Optional PR
+
+Only run this task if the user asks for push/PR.
+
+**Files:**
+- No file edits.
+
+- [ ] **Step 1: Push branch**
+
+Run:
+
+```bash
+git push -u origin feat/document-local-plugin-overrides
+```
+
+- [ ] **Step 2: Create PR**
+
+Run:
+
+```bash
+gh pr create \
+  --base main \
+  --head feat/document-local-plugin-overrides \
+  --title "docs: restructure build developer journey" \
+  --body "## Summary
+- reorganize Build docs around the internal developer journey
+- add workflow pages for local plugin workspaces, multi-plugin stacks, staging previews, and debugging pushes
+- keep detailed CLI, Gradle, manifest, config, portal, and concept references available under Reference
+
+## Validation
+- mintlify validate
+- git diff --check
+- stale text/link searches for upload limits, plugin versions, and group links"
+```
+
+Expected: GitHub returns the PR URL.

--- a/docs/superpowers/specs/2026-05-14-build-docs-developer-journey-design.md
+++ b/docs/superpowers/specs/2026-05-14-build-docs-developer-journey-design.md
@@ -1,0 +1,296 @@
+# Build Docs Developer Journey Design
+
+## Goal
+
+Restructure the Build docs around the internal developer journey while
+preserving all existing information.
+
+The Build section should answer the questions internal developers ask while
+working in real Grounds repositories:
+
+1. How do I set up my machine and repos?
+2. How do I push one plugin?
+3. How do I work across independent plugin repositories?
+4. How do I test multiple plugins together?
+5. How do I share a staging preview?
+6. How do I debug a failed push?
+7. Where is the exact reference for fields, flags, tasks, and config files?
+
+## Audience
+
+Primary audience: internal Grounds developers working across multiple
+independent plugin repositories.
+
+Secondary audience: external or future developers who need the same reference
+material. Their path remains supported through the reference pages, but the
+Build navigation prioritizes internal workflows.
+
+## Non-goals
+
+- Do not remove existing Build information.
+- Do not rewrite the Deploy or Reference tabs.
+- Do not change product behavior or code.
+- Do not make the Build docs a single long tutorial.
+- Do not duplicate flag tables, manifest field tables, or config precedence
+  tables across workflow pages.
+
+## Content Preservation Rule
+
+All current Build information must remain available after the restructure.
+
+Existing reference pages should keep their detailed content:
+
+- `build/cli/*`
+- `build/gradle-plugin/*`
+- `build/manifest`
+- `build/concepts/*`
+- `build/portal/*`
+- `build/ci-tokens`
+- `build/observability`
+- `build/troubleshooting`
+- `build/test-environment/*`
+
+Workflow pages may summarize and link to those references, but the reference
+pages remain authoritative for exact flags, fields, Gradle properties, and
+configuration precedence.
+
+If content moves, the source page must keep either the detailed reference
+content or a clear link to the new workflow page.
+
+## Canonical Internal Sample
+
+Use one recurring real sample for workflow pages:
+
+```text
+~/grounds/
+  sample-plugin-workspace/
+    app/
+      grounds.yaml
+  plugin-agones/
+  plugin-player/
+```
+
+The sample app is a Velocity plugin stack:
+
+```yaml
+name: sample-velocity-plugins
+type: plugin-velocity
+baseImage: velocity
+plugins:
+  - id: plugin-agones
+    variant: velocity
+    source: github:groundsgg/plugin-agones@v0.5.0
+  - id: plugin-player
+    variant: velocity
+    source: github:groundsgg/plugin-player@v0.1.0
+```
+
+The workspace maps local sibling repositories:
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-agones-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+
+grounds workspace add plugin-player ~/grounds/plugin-player \
+  --variant velocity \
+  --artifact velocity/build/libs/plugin-player-velocity.jar \
+  --build './gradlew :velocity:shadowJar'
+```
+
+Use fictional names such as `plugin-chat` and `plugin-permissions` only in
+short reference snippets where concrete repository behavior is irrelevant.
+
+## Navigation Design
+
+The Build tab should become journey-first:
+
+```text
+Build
+├─ Overview                         build/index
+├─ Quickstart                       build/quickstart
+├─ Workflows
+│  ├─ Local development             build/local-development
+│  ├─ Local plugin workspaces       build/local-plugin-workspaces
+│  ├─ Multi-plugin stacks           build/multi-plugin-stacks
+│  ├─ Staging previews              build/share-staging-previews
+│  └─ Debug pushes                  build/debug-pushes
+├─ Concepts
+│  ├─ Projects and teams
+│  ├─ Targets
+│  ├─ Pushes
+│  ├─ Base images
+│  └─ Preview environments
+├─ Reference
+│  ├─ Manifest reference            build/manifest
+│  ├─ CLI
+│  │  ├─ Installation
+│  │  ├─ Auth
+│  │  ├─ Push
+│  │  ├─ Workspace
+│  │  ├─ Preview
+│  │  └─ Configuration
+│  ├─ Gradle plugin
+│  │  ├─ Setup
+│  │  ├─ groundsPush
+│  │  ├─ groundsPushRetry
+│  │  └─ groundsTestLocal
+│  ├─ CI tokens
+│  ├─ Portal
+│  │  ├─ Overview
+│  │  ├─ Control center access
+│  │  └─ Control center step-up
+│  └─ Observability
+├─ Troubleshooting                  build/troubleshooting
+└─ Internal test environment
+   ├─ Overview
+   └─ Bundle reference
+```
+
+Keep existing URLs stable where possible. Prefer navigation moves over file
+renames.
+
+## Page Responsibilities
+
+### `build/index`
+
+Role: Build section landing page.
+
+It should state that Build docs are now optimized for internal developer
+workflows and point readers to the quickstart, workflows, and reference areas.
+It should keep the existing high-level value proposition and under-the-hood
+summary.
+
+### `build/quickstart`
+
+Role: internal developer quickstart from a fresh workspace to a first useful
+push.
+
+It should include:
+
+1. Prerequisites: account, CLI, Java/Gradle, GitHub Packages token.
+2. Clone or arrange repositories under one parent directory.
+3. Log in with `grounds login`.
+4. Configure `grounds-push` credentials for GitHub Packages.
+5. Push a single plugin or app with release/default sources.
+6. Add workspace mappings for `plugin-agones` and `plugin-player`.
+7. Run `grounds push --with-local`.
+8. Check the push in Portal.
+9. Link to workflow and reference pages.
+
+The current public first-push information should be preserved in this page or
+linked from it.
+
+### `build/local-development`
+
+Role: local-only server loop with `groundsTestLocal`.
+
+Keep existing content. Move it into the Workflows group and add links to the
+workspace and multi-plugin workflow pages for cases where local-only testing is
+not enough.
+
+### `build/local-plugin-workspaces`
+
+Role: narrative workflow for local overrides across independent repositories.
+
+It should use the canonical `plugin-agones` + `plugin-player` Velocity example
+and show:
+
+- why release sources remain in `grounds.yaml`
+- where `workspace.yaml` lives
+- `workspace scan`
+- explicit `workspace add`
+- `workspace list`
+- `workspace doctor`
+- `grounds push --local`
+- `grounds push --with-local`
+- source table interpretation
+
+It should link to `build/cli/workspace` for exact command reference.
+
+### `build/multi-plugin-stacks`
+
+Role: explain how to test multiple plugins together.
+
+It should cover:
+
+- `plugins:` vs `jar:`
+- structured entries with `id`, `variant`, and `source`
+- release defaults
+- local overrides
+- Paper/Velocity/gamemode support
+- bundle upload shape
+- 100 MB cap
+- what goes to Portal/Forge
+
+It should link to `build/manifest` for exact field rules.
+
+### `build/share-staging-previews`
+
+Role: workflow for sharing builds through staging previews.
+
+It should preserve and compose information from the current quickstart and
+preview docs:
+
+- `grounds push --target=staging`
+- preview TTL
+- portal inspection
+- pinning previews
+- when to use staging instead of dev
+
+It should link to `build/cli/preview` and
+`build/concepts/preview-environments`.
+
+### `build/debug-pushes`
+
+Role: developer workflow for failed pushes.
+
+It should cover:
+
+- reading CLI output
+- interpreting local override source tables
+- checking `workspace doctor`
+- checking Gradle task failures
+- checking Portal push/app views
+- using `grounds logs`
+- using `grounds push retry`
+- common failure categories
+
+It should link to `build/troubleshooting`, `build/cli/push`,
+`build/gradle-plugin/groundsPush`, and `build/portal/index`.
+
+### Reference pages
+
+Role: detailed authoritative references.
+
+Keep existing content and update cross-links only where needed:
+
+- CLI pages contain exact flags and config behavior.
+- Gradle pages contain exact task inputs and behavior.
+- Manifest contains exact schema and constraints.
+- Concepts explain platform concepts.
+- Portal pages explain Portal behavior.
+- Troubleshooting remains the deeper error catalog.
+
+## Validation
+
+Run:
+
+```bash
+mintlify validate
+git diff --check
+rg -n "50 MB|0\\.5\\.0|/build/cli\\)|/build/concepts\\)" build docs.json
+```
+
+The `rg` command is a stale-content/link smoke check. Any match should be
+reviewed rather than blindly removed.
+
+Manual review:
+
+- `docs.json` navigation follows the journey-first map.
+- Every existing Build page is still reachable.
+- New workflow pages link to reference pages instead of copying large tables.
+- The quickstart includes repository setup.
+- The canonical internal sample is used consistently.
+


### PR DESCRIPTION
# Pull Request

## Description
Reorganizes the Build docs around the internal developer journey while keeping the existing CLI, Gradle, manifest, config, portal, concept, and troubleshooting references available. Adds workflow pages for local plugin workspaces, multi-plugin stacks, staging previews, and push debugging.

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues
- Fixes #

## Testing
- [ ] Unit tests pass
- [x] Manual testing completed
- [ ] New tests added for new functionality

Validation performed:
- mintlify validate
- git diff --check
- stale text/link searches for upload limits, plugin versions, and group links
- spec compliance review approved
- docs quality review approved after fixes

## Checklist
- [x] I have performed a self-review of my own code
- [ ] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)