### PR TITLE
docs(build): developer guides for game servers, routing, and runtime capabilities

### DIFF
--- a/build/concepts/connecting-players.mdx
+++ b/build/concepts/connecting-players.mdx
@@ -1,0 +1,105 @@
+---
+title: "Connecting players"
+description: "The hostname a player connects to, and the path from that hostname to your running server."
+---
+
+When you push a Minecraft workload, it comes with a hostname a player can connect to. This page covers what that hostname is, what sits between the player and your game logic, and how the same idea works for HTTPS `service` workloads.
+
+For what your gamemode actually becomes at runtime, see [Game servers](/build/concepts/game-servers). For which hostname a push lands on, see [Targets](/build/concepts/targets).
+
+## The hostname you get
+
+Every push gives you a hostname based on the workload name in your `grounds.yaml` and where it was deployed.
+
+| Workload | Target | Hostname |
+|---|---|---|
+| Minecraft (`plugin-paper`, `gamemode`, proxy) | `dev` | `<name>-<handle>.mc.grnds.io` |
+| Minecraft | `staging` | `<name>-pr<id>.mc.grnds.io` |
+| `service` (HTTPS) | `dev` | `<name>-<handle>.dev.grnds.io` |
+| `service` (HTTPS) | `staging` | `<name>-pr<id>.dev.grnds.io` |
+
+`<handle>` is your account handle, `<id>` is the [preview environment](/build/concepts/preview-environments) short ID. Minecraft hosts are covered by a wildcard `*.mc.grnds.io` certificate; HTTPS service hosts by `*.dev.grnds.io`. You don't register DNS or request a certificate — the hostname exists as soon as the push is ready.
+
+A `dev` push is connectable only by you. A `staging` push is public, so it's the one to hand to a teammate. See [Targets](/build/concepts/targets) for the full visibility rules.
+
+## The player path
+
+For a Minecraft connection, the player types your hostname and their client lands inside the cluster, where a Velocity proxy forwards them to one of your running game servers.
+
+```mermaid
+flowchart LR
+    P([Player client]) -->|MC handshake<br/>on your hostname| R[In-cluster router]
+    R -->|matches your<br/>Service| VEL[Velocity proxy]
+    VEL -->|forwards to a<br/>running lobby| GS[Your game server<br/>Agones-allocated]
+    GS -.->|discovered live| VEL
+```
+
+The pieces you care about:
+
+- **Routing in.** An in-cluster router reads the hostname out of the Minecraft handshake and sends the connection to the Service that owns that hostname. One hostname maps to one Service — this is what lets every push have its own host without a separate load balancer. (It matches the `mc-router.itzg.me/externalServerName` annotation forge stamps for you; you never set it by hand.)
+- **The Velocity proxy.** When your gamemode runs behind a proxy, the proxy is what players actually connect to. It discovers your live game servers through the cluster automatically — there's no static server list to maintain — and forwards each player to one.
+- **Your game server.** Velocity hands the player to a running server. For a gamemode, that's an Agones-allocated server from your fleet; see [Game servers](/build/concepts/game-servers) for how readiness and allocation work.
+
+<Note>
+The Anycast edge that fronts production proxies (GeoIP, nearest-region routing) is **not** on the `dev` or `staging` path. Those pushes reach Velocity through the in-cluster router directly. You don't need to think about the edge while iterating.
+</Note>
+
+## Lobbies and login routing
+
+When a player connects through a proxy, routing behaviour is driven by lobbies:
+
+- At least one **lobby** server must be running, or new logins are **denied** at the proxy. A gamemode fleet with zero ready servers means no one can get in.
+- A new login is sent to the first available lobby. From there your own plugin logic moves the player on (into a match, a queue, wherever).
+- A server's role (`lobby`, `game`, `match`) is set by the base image, not by you. Most gamemode developers never touch it.
+
+<Tip>
+"Login denied" almost always means no lobby is in a running state. Check that your fleet has at least one ready server before assuming a routing bug — `grounds logs deployment <name>` shows the server coming up.
+</Tip>
+
+## HTTPS service workloads
+
+A `service`-type workload isn't on the Minecraft path at all. It's exposed over plain HTTPS through standard ingress:
+
+- `dev`: `https://<name>-<handle>.dev.grnds.io`
+- `staging`: `https://<name>-pr<id>.dev.grnds.io`
+
+Push an HTTP server on port `8080`, and you get a public `https://` URL with a managed certificate — no proxy, no Velocity, no lobby logic. This is the supported way to ship a self-contained backend HTTP app today.
+
+<Warning>
+A first-class **domain service that other apps discover and call** (registered gRPC, method-level access control) is in progress and not yet pushable through the supported flow — that work is platform-deployed today. You can reach your own service at its own URL now; cross-app service calls are roadmap. Don't design around them yet.
+</Warning>
+
+## What's still WIP
+
+Be aware of which routing modes are real today:
+
+<AccordionGroup>
+<Accordion title="Direct gamemode URL (not wired)">
+Connecting straight to a gamemode's own `mc.grnds.io` hostname, bypassing a Velocity proxy, is a separate mode that isn't wired into the platform. A gamemode placed behind a proxy is reachable **through the proxy host only**.
+</Accordion>
+
+<Accordion title="Per-fleet and multi-fleet routing (not a developer-facing knob)">
+Routing today goes through the standard proxy discovery described above — one push, one proxy host. Per-fleet hostnames and multi-fleet routing for advanced topologies aren't something you configure or rely on yet.
+</Accordion>
+
+<Accordion title="Service host not resolving">
+Pushing a `service` workload and getting a public `https://<name>-<handle>.dev.grnds.io` URL works today — the wildcard host, ingress, and certificate are wired for you. If a host you expect doesn't come up after the push reports ready, raise it in `#grounds-platform`.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Game servers" icon="gamepad" href="/build/concepts/game-servers">
+What your gamemode push becomes — an Agones-managed group of servers — and how readiness drives routing.
+</Card>
+<Card title="Targets" icon="bullseye" href="/build/concepts/targets">
+Which hostname and visibility you get for dev, staging, and production.
+</Card>
+<Card title="Preview environments" icon="flask" href="/build/concepts/preview-environments">
+The public `pr<id>` hostnames every staging push creates.
+</Card>
+<Card title="Quickstart" icon="rocket" href="/build/quickstart">
+Push your first server and connect to it.
+</Card>
+</CardGroup>

--- a/build/concepts/game-servers.mdx
+++ b/build/concepts/game-servers.mdx
@@ -1,0 +1,191 @@
+---
+title: "Game servers"
+description: "What a pushed gamemode becomes at runtime — an Agones-managed pool of Minecraft servers — and what you control: replica count, readiness, and allocation, without touching Kubernetes."
+---
+
+When you push an app with `type: gamemode`, you don't get a single long-lived Minecraft server. You get a **pool of identical Minecraft servers** that the platform keeps warm, scales to a replica count you choose, and marks busy or free based on whether real players are inside them. The system underneath is [Agones](https://agones.dev), but you never write Agones config — you set one field in `grounds.yaml` and the platform does the rest.
+
+This page explains what your push turns into, the small set of knobs you control, and how a busy/free lifecycle is driven by actual player activity. For the manifest field details, see [the manifest reference](/build/manifest). For installing and configuring the plugin your server embeds, see the [Agones plugin reference](/reference/plugins/agones).
+
+<Info>
+This is for `type: gamemode` apps only. A `plugin-paper`, `plugin-velocity`, or `service` push
+runs as an ordinary single workload, not a scaled pool. Only `gamemode` apps become an
+Agones-managed fleet.
+</Info>
+
+## What your push becomes
+
+A `gamemode` push produces two things you should know by name, because they show up in logs and in the portal:
+
+<CardGroup cols={2}>
+<Card title="Fleet" icon="layer-group">
+  The **pool** of identical game servers, as a whole. This is the thing you control. You declare how
+  many servers you want kept ready, and the platform maintains that count and rolls the whole pool
+  on each re-push.
+</Card>
+<Card title="GameServer" icon="cube">
+  **One** Minecraft server in the pool, with a busy/free state. You don't create or delete these —
+  the platform spawns one per replica and replaces them as needed. You'll see them as the individual
+  pods behind your gamemode.
+</Card>
+</CardGroup>
+
+The mental model: **you manage the Fleet (the pool); the platform manages the individual GameServers (the members).** You never touch a GameServer directly. You set a replica count on the Fleet, and the platform keeps that many servers warm and ready for the next match.
+
+```mermaid
+flowchart LR
+    A["grounds push<br/>(type: gamemode)"] --> B["Fleet<br/>(your pool, replicas: N)"]
+    B --> C["GameServer 1"]
+    B --> D["GameServer 2"]
+    B --> E["GameServer N"]
+    C -.-> F["Velocity proxy<br/>routes players in"]
+    D -.-> F
+    E -.-> F
+```
+
+Each server in the pool runs a Grounds gamemode base image that already bundles `plugin-agones`. That plugin is what reports each server's busy/free state and what lets the Velocity proxy discover your servers and route players to them — you don't wire any of that.
+
+## What you control
+
+Everything you control lives in your `grounds.yaml`. There are exactly two relevant fields, and neither requires any Kubernetes knowledge.
+
+```yaml grounds.yaml
+name: my-minigame
+type: gamemode
+baseImage: paper-gamemode
+jar: build/libs/my-minigame-0.1.0.jar
+agones:
+  replicas: 3
+```
+
+| Field | What it does |
+|---|---|
+| `type: gamemode` | Tells the platform to run your app as a scaled, Agones-managed pool instead of a single server. |
+| `agones.replicas` | How many servers the platform keeps **ready** at once. Defaults to `1`. Allowed range is `1`–`20`. |
+
+Set `replicas` to how many simultaneous matches (or lobbies) you want capacity for. Raise it when one server can't hold the player count you need; values above 20 require a platform-side quota bump. See [`agones` in the manifest reference](/build/manifest#agones-optional-gamemode-only) for the field definition.
+
+<Note>
+The replica count is the number of servers kept **ready and warm**, not a hard player cap. Players
+land on a ready server, that server flips to busy, and the platform keeps spinning the pool back up
+to your replica count so there's always a free server for the next match.
+</Note>
+
+Everything else — the SDK sidecar, the busy/free state machine, the discovery wiring, the network MTU fix — is injected and managed for you. There is no Fleet YAML to write and no Kubernetes resource to edit.
+
+## Ready and Allocated: real players drive it
+
+Each server in your pool is always in one of two states that matter to you:
+
+<CardGroup cols={2}>
+<Card title="Ready" icon="circle-check">
+  Empty and available. The platform keeps a target number of `Ready` servers warm so a joining
+  player always has somewhere to land.
+</Card>
+<Card title="Allocated" icon="users">
+  In use. At least one player is on it. An `Allocated` server is protected — the platform won't reap
+  it out from under an active match.
+</Card>
+</CardGroup>
+
+What flips a server between these states is **actual player activity** — not a timer, a health check, or anything you call:
+
+<AccordionGroup>
+<Accordion title="A server boots → Ready (or Allocated if it restarted with players)">
+  When a fresh server comes up empty, it reports `Ready`. If a server restarts while players are
+  already connected, it converges straight to `Allocated` so it isn't treated as free.
+</Accordion>
+<Accordion title="First player joins → Allocated">
+  The moment a server goes from zero players to one, `plugin-agones` marks it `Allocated`. The
+  platform now treats it as in-use and protected.
+</Accordion>
+<Accordion title="Last player leaves → Ready">
+  When the final player disconnects, the server reports `Ready` again — empty and available for the
+  next match.
+</Accordion>
+<Accordion title="A safety loop reconciles every few seconds">
+  A background loop re-reads the live player count and corrects the state if any join/leave event was
+  missed. It is not instantaneous, but it keeps a server's state honest under normal minigame load.
+</Accordion>
+</AccordionGroup>
+
+The practical takeaway: **you don't manage occupancy.** Your gamemode plugin handles game logic; the bundled `plugin-agones` translates "are there players on this server" into the busy/free state, and the platform uses that to keep the pool healthy and route new players onto free servers.
+
+<Tip>
+You can watch your servers flip between `Ready` and `Allocated` as players join and leave from the
+deployment's logs — `grounds logs deployment <name>` — or the deployment detail page in the portal.
+</Tip>
+
+## Bases and the pinned Minecraft version
+
+A gamemode runs on a Grounds base image that already bundles `plugin-agones` plus the platform runtime plugins. You select it by key in `grounds.yaml`; you don't assemble it.
+
+| Base key | For | Bundles |
+|---|---|---|
+| `paper-gamemode` | Paper-based gamemode servers (the common case) | `plugin-agones-paper`, so each server reports `Ready`/`Allocated` automatically |
+| `velocity` | The proxy that sits in front of gamemodes and routes players | `plugin-agones-velocity` for server discovery |
+
+<Warning>
+**The Minecraft version is pinned, and it's pinned on purpose.** Every gamemode server and the
+Velocity proxy in front of it must speak the same Minecraft protocol version. If the proxy lagged
+behind the game servers, modern clients would be rejected with `Incompatible client`. The base
+images move the Paper and Velocity versions together so they always match — this is a platform
+concern, not something you set per app. Pick the base key; don't try to pin a Minecraft version
+yourself.
+</Warning>
+
+<Note>
+The server port is always `25565/TCP`. Custom Minecraft ports are not supported, and there are no
+UDP ports. You don't configure the port.
+</Note>
+
+For the image-level details of each base, see the [Paper container](/deploy/containers/paper) and [Velocity container](/deploy/containers/velocity) references.
+
+## How players reach your servers
+
+Players never connect to a GameServer directly. A Velocity proxy sits in front of your pool, discovers your servers automatically, and forwards joining players onto a `Ready` one. The same `plugin-agones` that reports busy/free state on your game servers also powers discovery on the proxy — so when you push a gamemode and set a replica count, routing is wired for you.
+
+There is one hard requirement to be aware of: **at least one lobby server must be running**, or the proxy rejects new logins. The full story — how the proxy discovers servers, how lobbies gate logins, and how players actually land in your gamemode — is covered in [Connecting players](/build/concepts/connecting-players).
+
+<Check>What you do: push `type: gamemode` and set `agones.replicas`.</Check>
+<Check>What's automatic: server discovery, busy/free routing, the proxy in front of your pool, and a server's `lobby`/`game` role (set by the base image, not declared in `grounds.yaml`).</Check>
+
+## Limits and honest caveats
+
+<AccordionGroup>
+<Accordion title="Replicas are capped at 1–20">
+  The manifest rejects a replica count below 1 or above 20. If you genuinely need more than 20 warm
+  servers, that's a platform-side quota bump, not a manifest change.
+</Accordion>
+<Accordion title="Custom health endpoints are not called">
+  The platform relies on standard pod readiness, not a `/health` route in your gamemode. Adding one
+  won't change how the platform decides a server is up.
+</Accordion>
+<Accordion title="The busy/free flip isn't frame-perfect">
+  State transitions are driven by player join/leave events plus a periodic reconcile loop. Under a
+  burst of simultaneous joins the `Allocated` flip can lag by a tick or a few seconds. This is fine
+  for typical minigame loads; don't build hard real-time guarantees on the exact transition moment.
+</Accordion>
+<Accordion title="Only bundle plugin-agones into a gamemode image">
+  The `paper-gamemode` and `velocity` bases already include the right `plugin-agones` build. Don't
+  add `plugin-agones` to a plain `plugin-paper` push — without the injected sidecar it has nothing to
+  talk to.
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Manifest reference" icon="file-code" href="/build/manifest">
+  The `gamemode` type and the `agones.replicas` field, with the full field list.
+</Card>
+<Card title="Connecting players" icon="route" href="/build/concepts/connecting-players">
+  How the Velocity proxy discovers your servers and routes players onto a ready one.
+</Card>
+<Card title="Agones plugin reference" icon="puzzle-piece" href="/reference/plugins/agones">
+  Per-platform install, environment variables, and the `/agones` operator command.
+</Card>
+<Card title="Pushes" icon="rocket" href="/build/concepts/pushes">
+  What happens to your JAR from upload to a running pool, and how to retry, roll back, and tail logs.
+</Card>
+</CardGroup>

--- a/build/observability.mdx
+++ b/build/observability.mdx
@@ -3,14 +3,16 @@ title: "Observability"
 description: "Where to look when something is wrong — logs, metrics, traces."
 ---
 
-Every workload pushed to the platform is wired into our LGTM stack:
+Every workload pushed to the platform is wired into our LGTM stack — **Loki** (logs), **Mimir** (metrics), **Tempo** (traces), and **Grafana** (exploration).
 
-- **Loki** — logs from build steps and running pods.
-- **Mimir** — Prometheus metrics from base images and platform components.
-- **Tempo** — distributed traces (where instrumentation exists).
-- **Grafana** — the dashboarding + exploration front-end.
+Most of the time you don't need Grafana directly. The supported, project-scoped way to see your app's signals is the **portal** and the **CLI**:
 
-Sign in with your Grounds Account at [grafana.platform.grnds.io](https://grafana.platform.grnds.io). Your project membership translates to which logs/metrics you can see.
+- **Logs** — your app's **Logs** tab in the portal, or `grounds logs deployment <name>`. These stream straight from your pod, scoped to your project.
+- **Metrics** — the deployment detail page in the portal shows CPU/memory and base-image metrics for your app.
+
+<Note>
+[grafana.platform.grnds.io](https://grafana.platform.grnds.io) is reachable for ad-hoc exploration if your Grounds Account has a `dev` or `admin` role — sign in with Keycloak. It is **not project-isolated** today, so treat it as an operator/debug surface rather than your primary, scoped view; lead with the portal and CLI above.
+</Note>
 
 ## Logs
 

--- a/build/runtime/backend-services.mdx
+++ b/build/runtime/backend-services.mdx
@@ -1,0 +1,160 @@
+---
+title: "Backend services"
+description: "What a service-type app is, how it builds and runs, and how a plugin reaches one — plus an honest read on what works today versus what's still early."
+---
+
+A **service** is a long-running backend app — no Minecraft world, no players, no Agones lifecycle. It's a plain JVM process that owns a domain (leaderboards, presence, shared config) and answers requests from the plugins running inside your game servers. You push it like any other app: `type: service` in your [`grounds.yaml`](/build/manifest), one JAR, `main` is the entrypoint.
+
+This page covers the two things a `service` can be today — a self-contained HTTP backend you push and reach at its own URL, and the in-progress gRPC **domain-service** model where other apps call you through a typed contract — and is honest about which is which.
+
+<Note>
+A service is not the in-game minigame framework. The minigame API (`PaperMinigame`, teams, phases) is plugin-side code that runs *inside* a game server. A service is a separate workload that plugins call *out* to. If you're writing gameplay, you want a plugin; if you're holding shared state that outlives a single round, you want a service.
+</Note>
+
+## Service vs. plugin
+
+The split is between **where game logic runs** and **where shared state lives**.
+
+| | In-game plugin | Backend service |
+|---|---|---|
+| `type` | `plugin-paper`, `plugin-velocity`, `gamemode` | `service` |
+| `baseImage` | `paper`, `velocity`, `paper-gamemode` | `service` |
+| Runtime | Paper / Velocity server | Plain JVM (`main` is the entrypoint) |
+| Lifecycle | Joins player sessions, ticks per game | Always-on request/response |
+| Owns | Gameplay, player-facing UX | Domain data, shared logic |
+| Role in a call | Client — it calls services | Server — it answers, today over HTTP |
+
+A plugin holds the gameplay; a service holds the truth. A Mob Rush round decides *when* it ends and *what* the score is; a leaderboard service makes that score durable and rankable. The service never touches Minecraft.
+
+## What you get when you push a service
+
+Push a `type: service` app and forge gives you a plain Kubernetes `Deployment` plus a `Service` and a public HTTPS `Ingress` (cert-manager TLS). Your container listens on port `8080` and you get a public `https://` URL. From the platform's point of view it's the same push pipeline as a plugin — build the image from your JAR, deploy, tail logs — just without a Minecraft runtime wrapped around it.
+
+```mermaid
+flowchart LR
+    Dev["grounds push<br/>(type: service)"] --> Build["build image<br/>from your JAR"]
+    Build --> Dep["Deployment + Service"]
+    Dep --> Ing["Ingress<br/>(cert-manager TLS)"]
+    Ing --> URL["public https:// URL"]
+    Plugin["Your plugin"] -. "calls" .-> URL
+```
+
+What this is good for today: a self-contained HTTP backend — an API your plugins hit, a webhook receiver, a small admin endpoint. You own the framework and the routes inside the JAR; Grounds owns the build, the deploy, and the public URL.
+
+<Warning>
+A service-type app **does not get a managed database**. There is no per-app Postgres provisioning in the push path — your app gets a `Deployment`, not a database. Managed Postgres for pushed apps is roadmap, not a today capability; if you need durable shared state right now, point your service at storage you run yourself. See [Databases](/build/runtime/databases) for what does and doesn't persist.
+</Warning>
+
+## Pushing a service
+
+A service uses the same flow as any other push — see [Pushes](/build/concepts/pushes) for the full lifecycle.
+
+<Steps>
+<Step title="Declare it in grounds.yaml">
+Set `type: service` and `baseImage: service`. Your JAR's `main` becomes the container entrypoint — no Minecraft, no plugin loading.
+
+```yaml grounds.yaml
+name: my-backend
+type: service
+baseImage: service
+```
+
+`service` is single-JAR only: the [`plugins:`](/build/manifest#plugins-optional) multi-JAR block is rejected for this type.
+</Step>
+
+<Step title="Push it">
+```bash
+grounds push
+```
+
+Build, image, deploy — the same pipeline as a plugin. Tail the build with `grounds logs <pushId>`.
+</Step>
+
+<Step title="Reach it at its URL">
+Once the push is `ready`, your service answers at its public HTTPS URL. Check **Deployments → your app** in the portal for the live URL and status, or tail runtime logs:
+
+```bash
+grounds logs deployment my-backend            # follow
+grounds logs deployment my-backend --no-follow # snapshot
+```
+</Step>
+</Steps>
+
+## Configuring a service
+
+A service is configured exactly like any other pushed app: per-deployment **environment variables** (shipped — use them today) and **encrypted secrets** (code is merged, but may not be switched on in your environment yet — secret writes return `503 secrets_unavailable` until the platform key is provisioned, while plain env vars keep working). Full detail, including the reserved `GROUNDS_` prefix and the once-only secret reveal, lives in [Environment variables and secrets](/build/runtime/environment-and-secrets).
+
+## How a plugin calls a service
+
+Today, with a self-pushed HTTP service, your plugin reaches it the ordinary way: you have a public HTTPS URL, so make an HTTP call to it. There's no automatic URL injection or auth wiring for arbitrary HTTP services — you hold the URL, you make the request.
+
+The richer, typed story below (declare a dependency, get a URL and a token injected, call over gRPC) is the in-progress domain-service model — read the next section before you build against it.
+
+## The domain-service model (early)
+
+There's a more ambitious model in flight: first-class **domain services** that expose a typed gRPC API, that other apps *discover and call* through the manifest, with auth handled for you. `LeaderboardService` is the first vertical slice. Here's how it's meant to work, and exactly how far it actually reaches today.
+
+The intended shape:
+
+- Services publish a wire contract (`.proto`) so both sides generate matching stubs. Contracts compile to **JVM 21 bytecode** so they load cleanly into Java 21 Paper plugins.
+- A consumer declares the service in a `services:` block; the platform injects a `<SERVICE>_SERVICE_URL` env var and a projected ServiceAccount token. Auth is k8s ServiceAccount tokens, not Keycloak — the consumer's SDK attaches the token, the service validates it.
+- A plugin asks the SDK for a channel and calls a typed stub — no URL, JWT, or channel lifecycle in your code.
+
+```kotlin
+val channel = GroundsServices.channel("leaderboard")
+val stub = LeaderboardServiceGrpc.newBlockingStub(channel)
+val rank = stub.getPlayerRank(request)
+```
+
+<Warning>
+**This is not a self-service capability yet.** The honest state today:
+
+- The first domain service (`service-leaderboard`) has **no `grounds.yaml`** — it's deployed by platform engineers, not via `grounds push`. You cannot currently push a first-class registered gRPC domain-service through the supported flow.
+- The consumer side (the `services:` declaration, the URL + token injection, a sample plugin) is wired, but `use:` is **documentation-only** — there's no registry or proto enforcement matching consumers to providers yet.
+- The dedicated namespace and deployment module for these services are still pending.
+
+So: you can push a self-contained HTTP service and reach it at its own URL today. You **cannot** yet push a registered gRPC domain service that other apps discover and call through the manifest. Treat the gRPC model as in-progress, not shipped.
+</Warning>
+
+## Talking to other apps over NATS (early)
+
+Separately from gRPC, your pushed app can declare an `events:` block to publish to (and subscribe on) the Grounds message bus. The platform parses it, stamps the matching permissions onto your app's identity, and injects `NATS_URL` — the deny-by-default security layer around this is solid.
+
+What's proven and what isn't:
+
+- **Publishing from your own app** is infra-wired and works at that level — e.g. a gamemode push declaring `events: mobrush.results dir: pub` gets the wiring to publish.
+- **Reliable cross-app pub/sub** — your app subscribing to and consuming *another independently-pushed app's* events end-to-end — has **not** been demonstrated through the supported flow. No app → NATS → app roundtrip between two separately pushed apps exists yet.
+
+Declare-and-publish is early-but-real; cross-app messaging is roadmap. Don't design a feature around two of your apps talking over NATS until that path is proven.
+
+## Where to look when it misbehaves
+
+For a pushed service, your supported, project-scoped surfaces are the same as for any app:
+
+- **Runtime logs** — **Deployments → your app → Logs** in the portal, or `grounds logs deployment <name>` (`--no-follow` to stop tailing). This tails your pod directly, scoped to your project.
+- **Build logs** — `grounds logs <pushId>`.
+- **Metrics** — the stat strip on the deployment detail page in the portal. If the metrics backend isn't configured you'll see a graceful `503`, not real numbers.
+
+<Note>
+Grafana at [grafana.platform.grnds.io](https://grafana.platform.grnds.io) is available for ad-hoc exploration if you have a `dev` or `admin` role on your Grounds Account (sign in with Keycloak). It is **not** project-isolated today — you may land as a global Viewer and see cluster-wide data — so treat it as an operator/internal tool, not your per-app log surface. For your own app's logs and metrics, use the portal and CLI above. See [Observability](/build/observability) for the full picture.
+</Note>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Manifest reference" icon="file-lines" href="/build/manifest">
+  The `type: service` workload shape, `baseImage` keys, and every other `grounds.yaml` field.
+</Card>
+
+<Card title="Pushes" icon="rocket" href="/build/concepts/pushes">
+  The push lifecycle a service moves through — build, deploy, ready, retry, roll back.
+</Card>
+
+<Card title="Environment variables and secrets" icon="key" href="/build/runtime/environment-and-secrets">
+  Per-deployment config for your service — plain env vars today, encrypted secrets once the platform key is live.
+</Card>
+
+<Card title="Config System" icon="sliders" href="/reference/plugins/config-system">
+  A worked plugin-plus-service pair — the Config Plugin and Config API — showing the consumer side of the model.
+</Card>
+</CardGroup>

--- a/build/runtime/databases.mdx
+++ b/build/runtime/databases.mdx
@@ -1,0 +1,112 @@
+---
+title: "Databases"
+description: "How persistent data works for your app — why a pushed app has no managed database today, and how to connect your own."
+---
+
+This page is about where your app's data lives: player progress, plugin data files, anything you need to survive a deploy. The short version: **a pushed app does not get a managed database, and it does not get durable storage from the platform.** A pushed app runs as a plain Deployment or an Agones Fleet — pod-local disk is **ephemeral** and is lost when the pod is replaced on your next push. For anything you need to keep, connect an external database and pass the connection string in as an [encrypted secret](/build/runtime/environment-and-secrets).
+
+## What survives a push, and what doesn't
+
+When you push to `dev`, forge replaces the previous deployment. The new pod starts from your image with a clean filesystem — nothing the old pod wrote to disk carries over, because forge does not attach a persistent volume to a pushed app.
+
+| Where your data is | Survives a `dev` push? |
+|---|---|
+| In an **external database** you connect to | Yes — it lives outside the cluster, untouched by your deploy |
+| **Baked into your image** (resource files, defaults) | Yes — it's part of every build |
+| **Pod-local disk** (files your pod writes at runtime) | No — the new pod gets a clean filesystem |
+| **In memory** | No — every push is a fresh process |
+
+On `staging` it's stricter still: each push spins up a fresh [preview environment](/build/concepts/preview-environments), so **nothing carries across staging pushes**. A clean slate every time is the point of a preview.
+
+<Warning>
+Do not rely on pod-local disk for anything you need after a redeploy. Writing player data or world state to a file in the container is fine for a single run, but it is **gone the moment you push again** — there is no managed volume reattaching it. Persist anything that matters in a database you control.
+</Warning>
+
+For the full lifecycle of what a push replaces, see [Pushes](/build/concepts/pushes).
+
+## There is no automatic per-app database
+
+A pushed app — a `plugin-paper`, `plugin-velocity`, `gamemode`, or `service` — runs in your namespace with no database attached. **Forge does not provision Postgres (or any database) for it.** There is no per-app database URL injected, no schema created, no connection string to discover.
+
+<Note>
+**Managed Postgres for developer apps is on the roadmap, not a today capability.** The platform runs Postgres for its own services and for shared dev-workspace infrastructure, but there is no supported flow that hands a pushed app its own provisioned database. If you need one, raise it in `#grounds-platform` with your app and data shape so it can be tracked.
+</Note>
+
+## Connect an external database
+
+This is the supported pattern today: run the database wherever you like (a managed Postgres, your own Redis, a hosted provider), and inject the connection details as an encrypted secret so they are never baked into your JAR or your manifest.
+
+<Steps>
+<Step title="Decide what your app reads">
+  Pick the env var names your code reads at startup — `DATABASE_URL`, `DB_PASSWORD`, whatever your framework expects.
+
+  Names **cannot** start with `GROUNDS_` (reserved for platform built-ins like `GROUNDS_TOKEN`). Everything else is yours.
+</Step>
+<Step title="Store the connection string as a secret">
+  Set sensitive values as encrypted secrets — not plain env vars — from the **Env** tab in the [portal](/build/portal). Forge encrypts them at rest and injects them at deploy time.
+
+  See [Environment and secrets](/build/runtime/environment-and-secrets) for the exact flow, naming and size rules, and the secrets rollout caveat.
+</Step>
+<Step title="Read it in your app">
+  Forge injects the secret into your container as an ordinary environment variable (via a Kubernetes `secretKeyRef`), so your code reads it like any other env var.
+
+  ```java
+  String url = System.getenv("DATABASE_URL");
+  ```
+</Step>
+<Step title="Push">
+  ```bash
+  grounds push
+  ```
+
+  Env vars and secrets you set are merged into the workload on the next push. Don't put connection strings in `grounds.yaml` — that file describes *what* you ship, not credentials.
+</Step>
+</Steps>
+
+<Warning>
+Encrypted secrets are **rolling out** and may not be enabled on every forge instance yet. The encryption key has to be provisioned platform-side first; until it is, a secret write returns a clear `503 secrets_unavailable` error and you'll see it in the CLI. Plain (non-secret) env vars are unaffected and always work. If a secret write 503s, that's a platform-config gap on the instance, not a mistake on your end — flag it in `#grounds-platform`. Full detail lives in [Environment and secrets](/build/runtime/environment-and-secrets).
+</Warning>
+
+## What about the Postgres in dev workspaces?
+
+If you've used a [test environment](/build/test-environment/index), you may have seen a Postgres running inside it. That is **shared throwaway infrastructure for the whole workspace bundle**, not a database provisioned for your specific app:
+
+- It's a disposable, fixed-credential Postgres that lives only inside the per-engineer workspace.
+- It exists for bundled platform services to share, and it is wiped with the workspace.
+- It is **not** how a pushed app gets durable storage, and it does not exist in production.
+
+Don't build on it as if it were your app's database. If your app needs Postgres, use the external-database pattern above and keep the connection string in a secret.
+
+## Limits and honest caveats
+
+<AccordionGroup>
+<Accordion title="Pod-local disk does not survive a push">
+  A pushed app has no managed volume. Files your pod writes at runtime live on ephemeral pod storage and are gone when the pod is replaced on your next push. Anything you need to keep belongs in a database you control.
+</Accordion>
+<Accordion title="Staging keeps nothing">
+  Every `staging` push is a fresh [preview environment](/build/concepts/preview-environments). Data written in one staging push is not visible in the next — by design.
+</Accordion>
+<Accordion title="No managed Postgres for apps yet">
+  There is no `grounds db create`, no auto-injected `DATABASE_URL`, no per-app schema. If a doc or example implies a pushed app gets a database automatically, that's aspirational — it isn't wired in the push flow today.
+</Accordion>
+<Accordion title="Secrets depend on platform config">
+  Encrypted secret writes can 503 if the forge instance hasn't been provisioned with its secret-encryption key. That gates only the encrypted path; plain env vars keep working. See [Environment and secrets](/build/runtime/environment-and-secrets).
+</Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Environment and secrets" icon="lock" href="/build/runtime/environment-and-secrets">
+  Set plain env vars and encrypted secrets — the supported way to pass a database connection string to your app.
+</Card>
+<Card title="Pushes" icon="rocket" href="/build/concepts/pushes">
+  What a push replaces and what survives it.
+</Card>
+<Card title="Preview environments" icon="flask" href="/build/concepts/preview-environments">
+  Why staging pushes keep nothing — each one is a clean slate.
+</Card>
+<Card title="Manifest reference" icon="file-code" href="/build/manifest">
+  Every field in `grounds.yaml`. Note: there is no database field — credentials go in secrets, not the manifest.
+</Card>
+</CardGroup>

--- a/build/runtime/environment-and-secrets.mdx
+++ b/build/runtime/environment-and-secrets.mdx
@@ -1,0 +1,158 @@
+---
+title: "Environment variables and secrets"
+description: "Configure your app at runtime with plain environment variables and encrypted secrets, and the platform env your app already receives."
+---
+
+Your app needs configuration: a feature flag here, an upstream URL there, an API key it must not bake into the image. Grounds gives you two ways to set that, plus a set of built-in variables the platform injects for you.
+
+- **Plain environment variables** — non-sensitive config. Stored as-is, rendered straight into your container's `env`. **Shipped — use these today.**
+- **Encrypted secrets** — sensitive values (API keys, tokens). Encrypted at rest, shown once, injected via a Kubernetes Secret. **Rolling out — see [the secrets caveat](#secrets-are-rolling-out) before you rely on it.**
+
+Both are set per deployment from the [portal](/build/portal) or the CLI — never edit Kubernetes objects directly. Forge owns that state and re-applies it on every push.
+
+<Note>
+Set values **per app**, not per project. Each deployment carries its own env and secrets; pushing a new build keeps them.
+</Note>
+
+## How values reach your process
+
+You set values once. Forge merges them into your workload and injects them as standard environment variables — read them however your language reads env (`System.getenv("…")` on the JVM). Plain vars become literal `env` values; secrets become a `secretKeyRef` into a per-app Kubernetes Secret. Either way, your code just sees an environment variable.
+
+```mermaid
+flowchart LR
+    You[Portal or CLI] -->|set plain| Forge[forge]
+    You -->|set secret| Forge
+    Forge -->|literal env value| Pod[Your container]
+    Forge -->|secretKeyRef| Pod
+```
+
+Changes apply on your **next push**. Forge also tries to live-patch the running Deployment or Fleet as a best effort, but treat "takes effect on next push" as the reliable contract — paused and workspace-bundled workloads only pick changes up when you push again.
+
+## The `GROUNDS_` prefix is reserved
+
+The platform injects its own built-in variables, and they all start with `GROUNDS_`. To stop your config from shadowing them, **any variable name starting with `GROUNDS_` is rejected** when you set plain vars or secrets (case-sensitive, exact prefix). Pick any other name and you're fine.
+
+The variables your app already receives without doing anything:
+
+| Variable | What it is | Who gets it |
+|---|---|---|
+| `GROUNDS_TOKEN` | A fresh, project-scoped service-account token, rotated on every deploy, for calling back into the platform (e.g. a Paper plugin syncing the Minecraft whitelist). | Minecraft workloads and other app types |
+| `NATS_URL` | Broker address for apps that declare an [`events`](/build/manifest) block. | Apps with declared events |
+
+<Note>
+`GROUNDS_TOKEN` here is **platform-issued and auto-rotated** — different from the `GROUNDS_TOKEN` *you* set in CI to authenticate `grounds push`. Same name, two contexts: in a running pod it's minted for you; in a pipeline you supply your own. See [CI tokens](/build/ci-tokens).
+</Note>
+
+## Naming and size rules
+
+The same rules apply to plain vars and secrets:
+
+| Rule | Detail |
+|---|---|
+| Name pattern | `^[A-Za-z_][A-Za-z0-9_]*$` (POSIX-style: letters, digits, underscores; no leading digit) |
+| Reserved prefix | Names **cannot** start with `GROUNDS_` |
+| Value size | Up to 8 KiB (UTF-8) per value |
+| Uniqueness | No duplicate names in one request |
+
+Setting plain vars is a **wholesale replace** — the list you send becomes the complete set, so include everything you want kept. You need `owner` or `editor` access on the project to change them.
+
+## Set plain environment variables
+
+<Steps>
+<Step title="Open your app">
+  In the [portal](/build/portal), go to **Deployments**, click your app, and open the **Env** tab.
+</Step>
+<Step title="Add or edit variables">
+  Add `KEY=value` rows for your non-sensitive config — log levels, feature flags, upstream hostnames. Names can't start with `GROUNDS_`.
+</Step>
+<Step title="Save">
+  Saving replaces the full plain-var set. Forge persists it and re-renders it into your workload.
+</Step>
+<Step title="Apply with a push">
+  Push your app to make the change take effect. Read the value at runtime as a normal environment variable.
+
+  ```java
+  String logLevel = System.getenv("LOG_LEVEL"); // -> "debug"
+  ```
+</Step>
+</Steps>
+
+<Tip>
+Plain env vars require no key, no special configuration, and nothing provisioned ahead of time. This is the reliable path — keep anything non-sensitive here.
+</Tip>
+
+## Set encrypted secrets
+
+<Warning id="secrets-are-rolling-out">
+**Secrets are rolling out and may not be enabled on every instance yet.** The code is complete — values are AES-256-GCM encrypted at rest and injected through a Kubernetes Secret — but a secret write needs the platform's encryption key provisioned on the forge instance you're talking to. Until that's in place, **writing a secret returns a clear `503 secrets_unavailable` error** telling you the key isn't provisioned. **Plain env vars are unaffected** and keep working. If you hit that error, fall back to a plain var for now or ask in `#grounds-platform` whether secrets are live on your environment.
+</Warning>
+
+When secrets are enabled on your instance, they behave like this:
+
+- You set a secret from the **Env** tab (or CLI), marking the value as secret.
+- Forge encrypts it with **AES-256-GCM** before storing it — the plaintext is never persisted in the clear.
+- The plaintext is echoed back to you **exactly once**, in the response that sets it. After that, listing shows only the name and when it changed — never the value. **Copy it then; you can't read it back.**
+- On deploy, forge decrypts it into a per-app Kubernetes Secret and injects it into your container via `secretKeyRef`, so your code reads it as a normal environment variable.
+
+<Steps>
+<Step title="Open the Env tab">
+  Same place as plain vars: **Deployments → your app → Env**.
+</Step>
+<Step title="Add a secret">
+  Add the variable, mark it as a **secret**, and paste the value. Same naming rules — no `GROUNDS_` prefix, up to 8 KiB.
+</Step>
+<Step title="Copy the revealed value">
+  The value is shown back to you **once**. Copy it now if you need a record — it won't be displayed again.
+</Step>
+<Step title="Apply with a push">
+  Push to inject the secret. Read it at runtime exactly like any other env var.
+</Step>
+</Steps>
+
+<Info>
+Encryption protects the secret **at rest** in the platform database. At deploy time the value lands in a Kubernetes Secret in your namespace, decrypted, so the in-cluster trust boundary is the same one that holds `GROUNDS_TOKEN`. This is config-grade secret handling, not an HSM.
+</Info>
+
+## Limits and what's not here yet
+
+<AccordionGroup>
+<Accordion title="No managed database for your app (yet)">
+  A pushed app does **not** get a Postgres database provisioned for it. There's no per-app managed database today — persistence is whatever volume your pod declares in its own namespace. Managed Postgres for developer apps is on the roadmap, not a current capability. If you need state now, point a secret at your own external database. See [Databases](/build/runtime/databases) for what persists across pushes and how to ask for managed Postgres.
+</Accordion>
+<Accordion title="Declaring + publishing NATS events is early">
+  Your `grounds.yaml` can declare an [`events`](/build/manifest) block, and forge wires the infrastructure: it stamps your app's service account, projects a token, and injects `NATS_URL`. A publish-only app (for example a gamemode emitting result events) is wired to publish, and the security layer (deny-by-default auth) is sound.
+
+  What is **not** proven: one pushed app reliably **subscribing to and consuming another pushed app's** events end to end. No app-to-app round trip through the supported push flow has been demonstrated. Declare-and-publish from your own app: early, works at the infrastructure level. Reliable cross-app messaging: treat as roadmap.
+</Accordion>
+<Accordion title="HTTP services work; registered gRPC domain-services don't (yet)">
+  You can push a `type: service` app today and get a Deployment, a Service, and a public `https://` URL with TLS — a self-contained HTTP service you reach at its own address works.
+
+  What's **not** here yet: a first-class **registered gRPC domain-service** that other apps discover and call through the supported flow (the in-progress Service Architecture work). The `services:` / `provides:` manifest fields are documentation today; there's no registry or proto enforcement on the push path. Build self-contained HTTP services now; cross-service gRPC discovery is in progress.
+</Accordion>
+</AccordionGroup>
+
+## Where to see your config in action
+
+To confirm your variables landed and your app is reading them, check its **runtime logs** — the supported, project-scoped surface:
+
+- Portal: **Deployments → your app → Logs**, or
+- CLI: `grounds logs deployment <name>` (it tails by default; pass `--follow=false` to read the current logs and exit).
+
+Both stream your pod's logs directly, scoped to your project. App metrics show on the deployment detail page. For the full picture, see [Observability](/build/observability).
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Portal" icon="browser" href="/build/portal">
+  Where the Env tab lives — set plain vars and secrets, see logs and metrics.
+</Card>
+<Card title="Manifest reference" icon="file-code" href="/build/manifest">
+  `grounds.yaml` fields, including the `events` block your app declares.
+</Card>
+<Card title="CI tokens" icon="robot" href="/build/ci-tokens">
+  The other `GROUNDS_TOKEN` — project-scoped tokens for non-interactive `grounds push`.
+</Card>
+<Card title="Observability" icon="chart-line" href="/build/observability">
+  Logs, metrics, and traces for a running app.
+</Card>
+</CardGroup>

--- a/build/runtime/messaging.mdx
+++ b/build/runtime/messaging.mdx
@@ -1,0 +1,184 @@
+---
+title: "Messaging with NATS"
+description: "How your apps exchange events over a permission-scoped NATS bus on Grounds — declaring events, the connection you get, subject isolation, and what works today versus what's still early."
+---
+
+Grounds gives your plugins, gamemodes, and services a shared [NATS](https://nats.io) message bus so they can publish and subscribe to events instead of polling or wiring up point-to-point HTTP. You declare which subjects your app touches in your [manifest](/build/manifest); at runtime your pod gets a connection that's already scoped to exactly those subjects — nothing to provision, no credentials to manage, and no way to read another tenant's traffic.
+
+You never mint a token, write a broker config, or manage NATS accounts — that's all platform machinery. From your side, messaging is two things: a small block in `grounds.yaml`, and a connection your code reads from the environment.
+
+<Warning>
+**Read the [maturity section](#what-works-today) before you build on this.** Declaring events and **publishing** from your own pushed app is wired at the infrastructure level and works for the publish direction. A full **cross-app roundtrip** — your app subscribing to and consuming another independently-pushed app's events through the supported push flow — has **not** been proven end to end yet. Treat reliable cross-app pub/sub as roadmap, not a shipped capability. This page describes the model and the honest current status, not a how-to for something that isn't there yet.
+</Warning>
+
+## The model for you
+
+Messaging on Grounds follows one rule: **you only get what you declare.**
+
+1. You add an `events:` block to `grounds.yaml` listing each subject and whether you publish to it, subscribe to it, or both.
+2. When you push, the platform records that declaration against your app and injects a connection — a `NATS_URL` and a short-lived identity token — into your pod.
+3. When your app connects, the broker grants it permissions derived from your declaration. If you declared `dir: pub` on `match.ended`, you can publish that subject and nothing else; you can't subscribe to it, and you can't touch subjects you never asked for.
+
+```mermaid
+flowchart LR
+    M["grounds.yaml<br/>events: block"] -->|grounds push| F[Grounds]
+    F -->|records what you declared| ID[Your app's identity]
+    F -->|injects NATS_URL + token| P[Your pod]
+    P -->|connect| B[(NATS bus)]
+    B -->|permissions scoped to<br/>exactly your declared subjects| P
+```
+
+The important consequence: **subjects are isolated per tenant.** Your app connects with its own identity, and the permissions it gets are computed from your declaration alone. Another developer's app on the same bus can't grant itself access to your subjects, and a denied-by-default policy means anything you didn't declare is off-limits. You don't configure any of this — it's the default you get.
+
+<Note>
+If your app has no `events:` block, it's simply not a bus participant — no `NATS_URL`, no token, no connection. Messaging is opt-in per app.
+</Note>
+
+## Declaring events
+
+Add an `events:` block to your `grounds.yaml`. Each entry is a subject plus a direction:
+
+```yaml grounds.yaml
+name: mobrush
+type: gamemode
+baseImage: paper-gamemode
+events:
+  - subject: mobrush.results
+    dir: pub          # this app publishes match results
+  - subject: config.updated
+    dir: sub          # this app reacts to config changes
+  - subject: lobby.chat
+    dir: both         # dir defaults to "both" if omitted
+```
+
+| Field | What it means |
+|---|---|
+| `subject` | The NATS subject. Must be **lowercase**, start with a letter, and contain only letters, digits, dots, and the NATS wildcards `*` (one token) and `>` (everything below). |
+| `dir` | `pub`, `sub`, or `both`. Defaults to `both`. Controls which permissions you're granted for that subject. |
+
+You can declare up to **50** entries. Subjects are validated at push time — a subject that breaks the rules above fails the push.
+
+<Tip>
+Declare the **narrowest** direction you actually need. `dir: pub` for a publisher and `dir: sub` for a consumer keeps your blast radius small and makes the intent of your app obvious to teammates reviewing the manifest.
+</Tip>
+
+## The connection you get
+
+After a push with an `events:` block, your pod has two values injected into its environment:
+
+| Variable | What it is |
+|---|---|
+| `NATS_URL` | The broker your app should connect to. The platform sets the right value for where your app landed — you don't choose it. |
+| `GROUNDS_TOKEN_FILE` | Path to a short-lived identity token file your client presents when connecting. The platform rotates it for you (~1h, picked up live — no pod restart). |
+
+You don't construct the URL or build credentials by hand. Read these from the environment and connect.
+
+<Tabs>
+<Tab title="Grounds SDK (recommended)">
+
+The SDK reads the injected environment and presents the token for you:
+
+```kotlin
+val events = GroundsEvents.connect()          // reads NATS_URL + GROUNDS_TOKEN_FILE
+events.on("config.updated") { msg -> /* react */ }
+events.publish("mobrush.results", payload)
+```
+
+You never touch the URL or the token. Connect, subscribe to subjects you declared `sub`/`both` on, publish to subjects you declared `pub`/`both` on.
+
+</Tab>
+<Tab title="Raw jnats">
+
+If you're not using the SDK, read the token from `GROUNDS_TOKEN_FILE` and present it as the connection bearer:
+
+```kotlin
+val token = File(System.getenv("GROUNDS_TOKEN_FILE")).readText().trim()
+val options = Options.Builder()
+    .server(System.getenv("NATS_URL"))
+    .authHandler(/* present token as bearer */)
+    .build()
+val nc = Nats.connect(options)
+```
+
+The token rotates roughly hourly. Re-read `GROUNDS_TOKEN_FILE` before each connect so a reconnect always presents the current token — or just use the SDK, which does this for you.
+
+</Tab>
+</Tabs>
+
+<Note>
+A freshly-changed `events:` block can take up to about a minute to take effect after a push, because the permission lookup is briefly cached. If a new subscription doesn't work immediately, give it a moment and reconnect.
+</Note>
+
+## Subject isolation
+
+Subjects are plain, lowercase strings on a shared bus. Two apps that both publish a bare `config.updated` are publishing the *same* subject — so today, **pick subject names that are unlikely to collide** (prefix them with your app or domain, e.g. `mobrush.results` rather than `results`).
+
+The permission layer keeps you from *reading or writing* subjects you didn't declare — that's enforced and is the real security boundary. What isn't automatic yet is **namespacing**: a richer per-project / per-target subject prefix that would make collisions structurally impossible is designed but not wired into the bus you connect to. Until it ships, naming discipline is your isolation against name clashes within the shared bus.
+
+<Info>
+The deny-by-default permission model — you can only touch subjects you declared — **is** the shipped behavior of the security layer. Automatic per-tenant subject *prefixing* is the part that's still on the roadmap. Don't rely on prefix-based isolation existing yet; rely on declaring narrowly and naming your subjects distinctly.
+</Info>
+
+## What works today
+
+Be realistic about maturity before you design around this.
+
+<CardGroup cols={2}>
+<Card title="Cross-server within one server set — proven" icon="circle-check">
+Two Minecraft servers behind the same bus relay messages by both declaring compatible subjects. This is verified end to end (a chat / direct-message relay between two Paper servers over one NATS), and it's the working reference for cross-server coordination.
+</Card>
+<Card title="Cross-app between separate pushes — early" icon="triangle-exclamation">
+Two **independently pushed** apps doing a full publish-then-consume roundtrip through the supported push flow has **not** been demonstrated. The permission scoping is wired and the security model is sound, but no app to bus to app message has been confirmed flowing the whole way. Treat it as roadmap.
+</Card>
+</CardGroup>
+
+Where the line is, concretely:
+
+<AccordionGroup>
+<Accordion title="Declaring events on your pushed app — works">
+Your `grounds.yaml` `events:` block is parsed, carried through the push, and recorded against your app's identity. Your pod gets `NATS_URL` and the token. This is real today for any pushed app that declares events.
+</Accordion>
+
+<Accordion title="Publishing from your own app — works at the infra level">
+A pushed app declaring `dir: pub` (for example a gamemode publishing `mobrush.results`) is wired to publish. The permission set grants exactly that, and the connection is scoped correctly. The publish path is the more mature direction.
+</Accordion>
+
+<Accordion title="Subscribing to and consuming another app's events — not yet proven e2e">
+No two independently-pushed apps have been shown to complete a publish-then-consume roundtrip through the supported flow. The internal debug tooling that reads the bus is **not** a pushed app and doesn't count as proof of the developer path. If your design depends on app B reliably consuming app A's events, that's unproven today — build a fallback or check in with the platform team before committing to it.
+</Accordion>
+
+<Accordion title="Persistence / replay of past events — not available">
+The bus delivers live messages to connected subscribers. There is no retained-history or replay stream you can rely on yet — an app that wasn't connected when a message was published won't see it later.
+</Accordion>
+</AccordionGroup>
+
+The security layer itself — declare, get a scoped connection, deny everything you didn't ask for — is sound and is the part you can trust. The gap is purely in the *cross-app delivery* path being unproven end to end, not in the isolation model.
+
+## Limits and caveats
+
+- **Subjects are flat strings.** Names are your only collision protection today; prefix them. Automatic per-tenant prefixing is roadmap.
+- **Opt-in only.** No `events:` block means no bus access — there's no implicit connection.
+- **Token rotates.** Re-read `GROUNDS_TOKEN_FILE` on each connect (or use the SDK) so rotation stays transparent; a connect-once raw client holds its original scope until it reconnects.
+- **Declaration changes lag briefly.** Allow up to ~a minute after a push for a changed `events:` block to take effect.
+- **No replay.** Only live messages reach connected subscribers; there's no history fetch you can depend on.
+- **Cross-app delivery is unproven.** Publishing works; another pushed app reliably consuming it does not, yet.
+
+## Related
+
+<CardGroup cols={2}>
+<Card title="Manifest reference" icon="file-code" href="/build/manifest">
+  Every field of `grounds.yaml`, including where the `events:` block sits in your app definition.
+</Card>
+
+<Card title="Pushes" icon="rocket" href="/build/concepts/pushes">
+  How a push goes from upload to a running pod — the step that injects your connection.
+</Card>
+
+<Card title="Observability" icon="chart-line" href="/build/observability">
+  Where to find your deployment logs and metrics when you're debugging what your app sent or received.
+</Card>
+
+<Card title="Platform test environment" icon="flask" href="/build/test-environment">
+  Spin up an isolated environment to iterate on a component that uses the bus.
+</Card>
+</CardGroup>

--- a/docs.json
+++ b/docs.json
@@ -39,7 +39,18 @@
               "build/concepts/targets",
               "build/concepts/pushes",
               "build/concepts/base-images",
-              "build/concepts/preview-environments"
+              "build/concepts/preview-environments",
+              "build/concepts/game-servers",
+              "build/concepts/connecting-players"
+            ]
+          },
+          {
+            "group": "Runtime",
+            "pages": [
+              "build/runtime/environment-and-secrets",
+              "build/runtime/databases",
+              "build/runtime/messaging",
+              "build/runtime/backend-services"
             ]
           },
           {


### PR DESCRIPTION
Folds the genuinely developer-useful platform concepts into the **Build** tab as helpful, honest developer docs — reframed as "what you do and get" rather than platform internals, and grounded in **current capability maturity** (verified against the code) instead of the roadmap.

## New pages

**Concepts**
- `game-servers` — what a gamemode push becomes under Agones (Fleet/GameServer, Ready/Allocated, replicas) without touching Kubernetes
- `connecting-players` — how a player actually reaches your server (`<mode>-<handle>.mc.grnds.io` → edge → Velocity → your allocated server)

**Runtime** (new group — what your app gets at runtime)
- `environment-and-secrets` — per-app env vars (shipped) + encrypted secrets (rolling out; writes 503 until the key is provisioned + the carrying release deploys)
- `databases` — what survives a push; **honest** that there's no managed per-app database today (persist in an external DB via a secret; managed Postgres is roadmap)
- `messaging` — declaring + publishing NATS events from your `grounds.yaml`; **honest** that reliable cross-app pub/sub is not yet proven
- `backend-services` — the `service` type (push an HTTP service, get a URL) vs the in-progress first-class gRPC domain-service story

## Cleanup
- Corrects `build/observability`: `grafana.platform.grnds.io` is reachable but **not project-isolated**, so the supported per-developer surfaces (portal **Logs** tab, `grounds logs`, portal metrics) now lead; Grafana is framed as an operator/ad-hoc tool.
- The earlier (overly internal) standalone Architecture tab from this branch was dropped in favor of this developer-focused integration.

## How it was produced
Capability maturity was verified against the real code first (env vars, secrets, Postgres, NATS-from-app, services, Grafana access), then each page was written from that ground-truth and reviewed on two axes: **developer usefulness** and **accuracy/honesty** (no roadmap-as-shipped). Pages mark early/unavailable capabilities plainly.

## Validation
All internal links resolve, frontmatter + MDX-safety checks pass, `docs.json` nav fully covers the new pages. Relying on the Mintlify preview build on this PR for the authoritative check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)