### PR TITLE
docs: document runtime module workflows

### DIFF
--- a/build/cli/push.mdx
+++ b/build/cli/push.mdx
@@ -8,7 +8,7 @@ description: "Build with Gradle, upload to forge, deploy to a target."
 ## Synopsis
 
 ```text
-grounds push [--target=dev|staging] [--project <id>] [--local <id>[,<id>]] [--with-local]
+grounds push [--target=dev|staging] [--flavor <key>] [--project <id>] [--local <id>[,<id>]] [--with-local]
 grounds push retry <pushId>
 grounds push list [--target T] [--status S] [--limit N]
 ```
@@ -18,6 +18,7 @@ grounds push list [--target T] [--status S] [--limit N]
 ```bash
 grounds push --target=dev       # default
 grounds push --target=staging
+grounds push --flavor=minestom
 grounds push --local plugin-chat
 grounds push --local plugin-chat,plugin-permissions
 grounds push --with-local
@@ -69,6 +70,49 @@ plugin-player   velocity  release     github:groundsgg/plugin-player@v0.1.0
 
 The table is the confirmation step. It shows which plugins use local artifacts
 and which still use release sources.
+
+### Minestom distribution pushes
+
+For `type: minestom-server`, the CLI uses the Minestom path instead of delegating to the Gradle
+`groundsPush` task. It reads `build.task`, builds the configured distribution, normalizes
+`build.artifact`, and uploads the tar artifact to Forge.
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :examples:minigame-agones:distTar
+  artifact: examples/minigame-agones/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+Run the push from the directory that contains `gradlew` and `grounds.yaml`:
+
+```bash
+grounds push --target=dev
+```
+
+If the manifest uses `flavors`, select the Minestom flavor explicitly:
+
+```bash
+grounds push --flavor=minestom --target=dev
+```
+
+Minestom module entries use the same `--local` and `--with-local` flags as plugin stacks. When
+local mappings apply, the CLI prints the effective source table before running Gradle:
+
+```text
+Bundle sources:
+ID              Variant   Effective   Value
+plugin-agones   minestom  local       /home/alice/grounds/plugin-agones
+```
+
+See [Local Minestom Modules](/reference/development/minestom-runtime/local-modules) for the
+workspace mapping details.
 
 ## push retry
 

--- a/build/local-plugin-workspaces.mdx
+++ b/build/local-plugin-workspaces.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Work with local plugin workspaces"
-description: "Override release plugin sources with local builds from independent repositories."
+description: "Override release plugin or module sources with local builds from independent repositories."
 ---
 
-Local plugin workspaces let you keep `grounds.yaml` pointed at release plugin
+Local workspaces let you keep `grounds.yaml` pointed at release plugin or module
 sources while opting into local builds for a single push. Use this workflow when
-your app lives in one repository and the plugin dependencies you are changing
-live in sibling repositories.
+your app lives in one repository and the plugin or Minestom module dependencies
+you are changing live in sibling repositories.
 
 <Tip>
 Local overrides are machine-local. They do not change the manifest, and they
@@ -28,7 +28,7 @@ Use the internal sample workspace as the reference shape:
 
 Run `grounds push` from `~/grounds/sample-plugin-workspace/app`. Keep
 `plugin-agones` and `plugin-player` beside the app repository so the CLI can map
-release plugin IDs to the local repositories on your machine.
+release plugin or module IDs to the local repositories on your machine.
 
 Your manifest stays portable:
 
@@ -44,7 +44,8 @@ plugins:
 
 The `id` and `variant` fields are the matching keys. The `source` fields remain
 the default release sources for teammates, CI, and any push that does not opt
-into local overrides.
+into local overrides. Minestom server manifests use the same idea under
+`modules`.
 
 ## Scan for repositories
 
@@ -86,6 +87,38 @@ grounds workspace add plugin-player ~/grounds/plugin-player \
 The artifact path is relative to the plugin repository. The build command runs
 inside that repository before the artifact is resolved.
 
+## Add Minestom module mappings
+
+For Minestom runtime modules, add a mapping for the `minestom` variant:
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones --variant minestom
+```
+
+If Gradle composite substitution needs explicit coordinates, add `module` and
+`project` to `workspace.yaml`:
+
+```yaml
+repos:
+  plugin-agones:
+    path: /home/alice/grounds/plugin-agones
+    variants:
+      minestom:
+        enabled: true
+        module: gg.grounds:plugin-agones-minestom
+        project: :minestom
+```
+
+When both fields are present, the CLI generates a temporary Gradle init script
+that includes the local repository and substitutes the release module with the
+local project.
+
+<Note>
+For Minestom module substitution, the app's Gradle distribution task builds against the included
+local repository. The workspace `artifact` and `build` fields are used for plugin artifact
+overrides and are not the source of truth for the Minestom runtime classpath.
+</Note>
+
 ## Inspect mappings
 
 List the workspace entries before pushing:
@@ -100,7 +133,7 @@ Use `doctor` when a mapping does not behave as expected:
 grounds workspace doctor
 ```
 
-`workspace list` shows each plugin ID, variant, enabled state, repository path,
+`workspace list` shows each plugin or module ID, variant, enabled state, repository path,
 artifact path, and build command. `workspace doctor` checks whether configured
 paths exist and reports missing local repositories.
 
@@ -115,6 +148,7 @@ grounds push --target=dev --local plugin-agones
 
 The app manifest still reads both plugins from release sources, but the CLI
 replaces `plugin-agones` with the local Velocity artifact for this one push.
+For Minestom manifests, `--local` selects matching entries from `modules`.
 
 You can pass multiple local plugin IDs as a comma-separated value:
 
@@ -138,7 +172,8 @@ grounds push --target=dev --with-local
 ```
 
 This is the usual internal loop for the sample workspace after both Velocity
-artifacts are pinned. Disabled mappings are ignored.
+artifacts are pinned. It also applies to enabled Minestom module mappings.
+Disabled mappings are ignored.
 
 ## Disable a mapping temporarily
 
@@ -176,3 +211,4 @@ move this file together with the rest of the CLI config. See
 - [Push CLI reference](/build/cli/push)
 - [Configuration reference](/build/cli/configuration)
 - [Build multi-plugin stacks](/build/multi-plugin-stacks)
+- [Local Minestom Modules](/reference/development/minestom-runtime/local-modules)

--- a/build/manifest.mdx
+++ b/build/manifest.mdx
@@ -27,6 +27,8 @@ resources:
 ```
 
 Multi-plugin servers ship multiple JARs onto one Paper / Velocity / gamemode workload — see [`plugins`](#plugins-optional) below.
+Minestom servers ship one Gradle distribution tar — see
+[`minestom-server` manifests](#minestom-server-manifests).
 
 ## Fields
 
@@ -49,6 +51,7 @@ What kind of workload this is. One of:
 | `plugin-paper` | Bukkit/Paper plugin JAR | `paper` |
 | `plugin-velocity` | Velocity plugin JAR | `velocity` |
 | `gamemode` | Bukkit/Paper plugin JAR running as an Agones-managed gameserver | `paper-gamemode` |
+| `minestom-server` | Complete Minestom server distribution tar | `minestom` |
 | `service` | Plain JVM app (no Minecraft runtime) | `service` |
 
 `type` drives quotas, resource defaults, port mappings, and which container our renderer wires up.
@@ -62,6 +65,7 @@ The catalog source key for the runtime image your JAR is layered onto. Must be o
 | `paper` | `ghcr.io/groundsgg/paper` | A Paper server with sane defaults, your JAR auto-loaded into `plugins/`. Use with `type: plugin-paper`. |
 | `paper-gamemode` | `ghcr.io/groundsgg/paper-gamemode` | Same as `paper`, but pre-bundled with `plugin-agones-paper` so the SDK sidecar (injected on every Fleet pod) reports Allocated/Ready from player events. Use with `type: gamemode`. |
 | `velocity` | `ghcr.io/groundsgg/velocity` | A Velocity proxy with your JAR in `plugins/`. |
+| `minestom` | `eclipse-temurin` | A JVM base image for a complete Minestom distribution. Use with `type: minestom-server`. |
 | `service` | `ghcr.io/groundsgg/jvm-service` | Generic JVM runner — your JAR's `main` is the entrypoint, no Minecraft runtime. |
 
 Forge resolves the source key to the current stable version in the [base image catalog](/build/concepts/base-images) when it builds your push. Do not put an OCI tag or digest in `grounds.yaml`; promote a new catalog version instead.
@@ -78,6 +82,59 @@ When to set it explicitly:
 
 - You produce multiple JARs and want to ensure the right one is picked.
 - You build with something other than `shadowJar` / `jar`.
+
+<Warning>
+Do not use `jar:` for `type: minestom-server`. Minestom pushes upload the distribution tar from
+[`build.artifact`](#build-minestom-server-only), not a single JAR.
+</Warning>
+
+### Minestom server manifests
+
+Use `type: minestom-server` when you push a complete Minestom server application.
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :examples:minigame-agones:distTar
+  artifact: examples/minigame-agones/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+Minestom has no plugin folder. Your Gradle project builds one runnable distribution that already
+contains the runtime, your game code, and the module dependencies selected by your application.
+
+#### `build` (Minestom server only)
+
+`build` tells the CLI how to create and find the Minestom distribution artifact before upload.
+
+| Field | Required | What it does |
+| --- | --- | --- |
+| `task` | Yes | Gradle task the CLI runs, such as `:server:distTar`. |
+| `artifact` | Yes | Glob for the generated distribution tar, relative to the project root. |
+
+The artifact must be a Gradle-style tar distribution (`.tar`, `.tar.gz`, or `.tgz`). The CLI
+normalizes the archive before upload so Forge receives one consistent app tarball.
+
+#### `modules` (Minestom server only)
+
+`modules` lists release module sources that can be replaced with local workspace mappings during
+development.
+
+| Field | Required | What it does |
+| --- | --- | --- |
+| `id` | Yes | Stable module key used by `--local`, `--with-local`, and workspace mappings. |
+| `variant` | No | Artifact variant, usually `minestom`. |
+| `source` | Yes | Portable release source, usually a pinned GitHub release asset. |
+
+`modules` is CLI composition metadata. Gradle dependencies still define the actual compile and
+runtime classpath. Keep release sources in `grounds.yaml` and use
+[local module workspaces](/reference/development/minestom-runtime/local-modules) when you need to
+replace them on your machine.
 
 ### `plugins` (optional)
 

--- a/build/troubleshooting.mdx
+++ b/build/troubleshooting.mdx
@@ -61,6 +61,27 @@ resources:
 
 Local mode only runs Paper and Velocity. Use `grounds push --target=dev` for `minestom` / `service` workloads.
 
+### `type 'minestom-server' requires a distribution bundle`
+
+Forge received a JAR for a Minestom server push. `type: minestom-server` must upload a distribution
+tar built from `build.task` and matched by `build.artifact`.
+
+Check:
+
+- `grounds.yaml` has `build.task`, for example `:server:distTar`.
+- `grounds.yaml` has `build.artifact`, for example `server/build/distributions/*.tar`.
+- You are running `grounds push`, not manually uploading a JAR with an older tool.
+
+### `expected at least one distribution tar`
+
+The CLI ran the Minestom build task but the `build.artifact` glob did not match a tar file.
+
+Check:
+
+- The Gradle task actually creates a `.tar`, `.tar.gz`, or `.tgz` file.
+- The `build.artifact` path is relative to the directory containing `grounds.yaml`.
+- The glob is specific enough to avoid stale or unrelated files.
+
 ### `unknown baseImage`
 
 Your manifest references a base image source key that Forge does not know, or that is not allowed for the selected `type`.
@@ -109,6 +130,33 @@ Your manifest's `jar:` glob doesn't match any file. Check:
 - `./gradlew shadowJar` produces something at `build/libs/`.
 - The glob in `grounds.yaml` (or auto-detected) matches it.
 - The Gradle plugin successfully built before upload (look at the build output).
+
+### `Grounds module provider grounds.agones was requested but not discovered`
+
+The Minestom runtime selected a provider ID that was not on the distribution classpath.
+
+Check:
+
+- The server Gradle app has `runtimeOnly("gg.grounds:plugin-agones-minestom:0.6.0")` or newer.
+- The distribution tar contains the Agones Minestom JAR under `lib/`.
+- The runtime calls `discoverProviders()` before `useProvider("grounds.agones")`.
+- The selected ID matches the provider ID exactly: `grounds.agones`.
+
+### `local module requires both module and project for dependency substitution`
+
+A Minestom workspace mapping has only one of `module` or `project` configured. Set both fields or
+remove both fields and let Gradle's default composite substitution handle it.
+
+```yaml
+repos:
+  plugin-agones:
+    path: /home/alice/grounds/plugin-agones
+    variants:
+      minestom:
+        enabled: true
+        module: gg.grounds:plugin-agones-minestom
+        project: :minestom
+```
 
 ### Build hangs in `building` for >5 minutes
 

--- a/docs.json
+++ b/docs.json
@@ -164,6 +164,21 @@
             ]
           },
           {
+            "group": "Development libraries",
+            "pages": [
+              "reference/development/jvm-modules/service-registry",
+              {
+                "group": "Minestom Runtime",
+                "pages": [
+                  "reference/development/minestom-runtime/index",
+                  "reference/development/minestom-runtime/modules",
+                  "reference/development/minestom-runtime/composition",
+                  "reference/development/minestom-runtime/local-modules"
+                ]
+              }
+            ]
+          },
+          {
             "group": "Conventions",
             "pages": [
               "reference/development/naming-conventions",

--- a/docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
+++ b/docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
@@ -1,0 +1,433 @@
+# Runtime Feature Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish public Mintlify docs for the new JVM service registry, Minestom runtime modules, Minestom distribution pushes, local Minestom module substitution, and Agones provider-based Minestom integration.
+
+**Architecture:** Keep reusable API documentation under `Reference > Development libraries`, keep push/deploy workflow documentation under `Build`, and keep Agones-specific behavior under `Reference > Plugins SDK > Agones Integration`. The docs repo is the canonical public site; implementation repositories remain source-of-truth inputs.
+
+**Tech Stack:** Mintlify MDX, `docs.json` navigation, Kotlin/Gradle examples, Grounds CLI/Forge manifest examples.
+
+---
+
+## File Structure
+
+- Create `reference/development/jvm-modules/service-registry.mdx`: standalone `library-jvm-modules` service registry reference.
+- Create `reference/development/minestom-runtime/index.mdx`: Minestom runtime overview.
+- Create `reference/development/minestom-runtime/modules.mdx`: module/provider/service contract API reference.
+- Create `reference/development/minestom-runtime/composition.mdx`: runtime composition and provider selection guide.
+- Create `reference/development/minestom-runtime/local-modules.mdx`: local Minestom module substitution workflow.
+- Modify `docs.json`: add a `Development libraries` group under the Reference tab.
+- Modify `build/manifest.mdx`: document `minestom-server`, `build`, and `modules`.
+- Modify `build/cli/push.mdx`: document Minestom push behavior.
+- Modify `build/local-plugin-workspaces.mdx`: generalize plugin wording and add Minestom module examples.
+- Modify `build/troubleshooting.mdx`: add Minestom troubleshooting entries.
+- Modify `reference/plugins/agones/minestom.mdx`: make provider-based integration the primary path.
+
+## Task 1: Add Development Library Navigation And Service Registry Docs
+
+**Files:**
+- Modify: `docs.json`
+- Create: `reference/development/jvm-modules/service-registry.mdx`
+
+- [ ] **Step 1: Add navigation group**
+
+Update `docs.json` in the Reference tab after `Convention plugins` or before `Conventions`:
+
+```json
+{
+  "group": "Development libraries",
+  "pages": [
+    "reference/development/jvm-modules/service-registry",
+    {
+      "group": "Minestom Runtime",
+      "pages": [
+        "reference/development/minestom-runtime/index",
+        "reference/development/minestom-runtime/modules",
+        "reference/development/minestom-runtime/composition",
+        "reference/development/minestom-runtime/local-modules"
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 2: Write service registry page**
+
+Create `reference/development/jvm-modules/service-registry.mdx` with:
+
+- frontmatter title `Service Registry`;
+- overview of type-first service access;
+- `DefaultServiceRegistry` example;
+- `serviceKey<T>()` and class-based overload examples;
+- `qualifiedServiceKey<T>()` guidance for multiple implementations;
+- descriptor example with `requires`, `provides`, and `dependsOn`;
+- failure behavior for duplicate and missing services.
+
+Use these concrete API examples:
+
+```kotlin
+val registry = DefaultServiceRegistry()
+
+registry.register<MyService>(DefaultMyService())
+
+val service = registry.require<MyService>()
+```
+
+```kotlin
+registry.register(MyService::class, DefaultMyService())
+
+val service = registry.require(MyService::class)
+```
+
+```kotlin
+object NatsServiceKeys {
+    val Public = qualifiedServiceKey<NatsClient>("grounds.nats.public")
+    val Internal = qualifiedServiceKey<NatsClient>("grounds.nats.internal")
+}
+```
+
+```kotlin
+override val descriptor =
+    ModuleDescriptor(
+        id = "grounds.matchmaking",
+        version = "1.0.0",
+        requires = setOf(NatsServiceKeys.Internal),
+        provides = setOf(serviceKey<MatchmakingService>()),
+        dependsOn = setOf("grounds.config"),
+    )
+```
+
+- [ ] **Step 3: Verify task 1 paths**
+
+Run:
+
+```bash
+test -f reference/development/jvm-modules/service-registry.mdx
+rg -n "reference/development/jvm-modules/service-registry|Development libraries" docs.json
+```
+
+Expected: both commands exit `0`.
+
+## Task 2: Add Minestom Runtime Reference Pages
+
+**Files:**
+- Create: `reference/development/minestom-runtime/index.mdx`
+- Create: `reference/development/minestom-runtime/modules.mdx`
+- Create: `reference/development/minestom-runtime/composition.mdx`
+- Create: `reference/development/minestom-runtime/local-modules.mdx`
+
+- [ ] **Step 1: Write overview page**
+
+Create `reference/development/minestom-runtime/index.mdx` with:
+
+- title `Minestom Runtime`;
+- explanation that Minestom has no hot plugin folder;
+- build-time composition and immutable distributions;
+- cards linking to modules, composition, local modules, manifest, and Agones Minestom.
+
+- [ ] **Step 2: Write module API page**
+
+Create `reference/development/minestom-runtime/modules.mdx` with:
+
+- `GroundsModule` lifecycle code;
+- `GroundsModuleProvider` code;
+- `ModuleDescriptor` use;
+- `serverTypes` compatibility;
+- service contract declarations.
+
+Use this API shape:
+
+```kotlin
+interface GroundsModule {
+    val id: String
+
+    fun install(ctx: GroundsServerContext)
+
+    fun start() {}
+
+    fun stop() {}
+}
+```
+
+```kotlin
+class MatchmakingModuleProvider : GroundsModuleProvider {
+    override val id = "grounds.matchmaking"
+    override val version = "1.0.0"
+    override val serverTypes = setOf(ServerType.MINIGAME)
+    override val descriptor =
+        ModuleDescriptor(
+            id = id,
+            version = version,
+            requires = setOf(serviceKey<PlayerService>()),
+            provides = setOf(serviceKey<MatchmakingService>()),
+        )
+
+    override fun create(): GroundsModule = MatchmakingModule()
+}
+```
+
+- [ ] **Step 3: Write composition page**
+
+Create `reference/development/minestom-runtime/composition.mdx` with:
+
+- `GroundsServer.builder()`;
+- direct `use(provider)`;
+- `discoverProviders()`;
+- `useProvider("grounds.agones")`;
+- selected provider validation failure text;
+- startup lifecycle order.
+
+Use this example:
+
+```kotlin
+fun main() {
+    GroundsServer.builder()
+        .discoverProviders()
+        .useProvider("grounds.agones")
+        .use(ExampleMinigameModuleProvider())
+        .start()
+}
+```
+
+- [ ] **Step 4: Write local modules page**
+
+Create `reference/development/minestom-runtime/local-modules.mdx` with:
+
+- `grounds.yaml` `modules` entries;
+- workspace mappings with `variant: minestom`;
+- `--local` and `--with-local`;
+- Gradle composite build behavior;
+- when `module` and `project` metadata are needed.
+
+Use this manifest example:
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :examples:minigame-agones:distTar
+  artifact: examples/minigame-agones/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+- [ ] **Step 5: Verify task 2 paths**
+
+Run:
+
+```bash
+test -f reference/development/minestom-runtime/index.mdx
+test -f reference/development/minestom-runtime/modules.mdx
+test -f reference/development/minestom-runtime/composition.mdx
+test -f reference/development/minestom-runtime/local-modules.mdx
+```
+
+Expected: command exits `0`.
+
+## Task 3: Update Build Workflow Docs For Minestom Distributions
+
+**Files:**
+- Modify: `build/manifest.mdx`
+- Modify: `build/cli/push.mdx`
+- Modify: `build/local-plugin-workspaces.mdx`
+- Modify: `build/troubleshooting.mdx`
+
+- [ ] **Step 1: Update manifest reference**
+
+Modify `build/manifest.mdx`:
+
+- add `minestom-server` to the `type` table;
+- add `minestom` to the `baseImage` table;
+- add sections for `build` and `modules`;
+- explain that `minestom-server` requires a distribution tar, not `jar`;
+- clarify that `modules` is CLI composition metadata for release defaults and local substitution, while Gradle dependencies still define the classpath.
+
+- [ ] **Step 2: Update push CLI reference**
+
+Modify `build/cli/push.mdx`:
+
+- add `--flavor=<key>` to synopsis examples;
+- explain Minestom detection from `grounds.yaml`;
+- document that CLI runs `build.task`, normalizes `build.artifact`, uploads it to Forge, and prints the effective source table when local module mappings apply.
+
+- [ ] **Step 3: Update local workspace docs**
+
+Modify `build/local-plugin-workspaces.mdx`:
+
+- change the intro from only plugin workspaces to plugin/module workspaces;
+- keep existing Paper/Velocity examples;
+- add a Minestom module example:
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones \
+  --variant minestom \
+  --build './gradlew :minestom:build'
+```
+
+- describe optional `workspace.yaml` fields:
+
+```yaml
+repos:
+  plugin-agones:
+    path: /home/alice/grounds/plugin-agones
+    variants:
+      minestom:
+        enabled: true
+        module: gg.grounds:plugin-agones-minestom
+        project: :minestom
+```
+
+- [ ] **Step 4: Update troubleshooting**
+
+Modify `build/troubleshooting.mdx` with Minestom sections:
+
+- `type 'minestom-server' requires a distribution bundle`;
+- `expected at least one distribution tar`;
+- `Grounds module provider grounds.agones was requested but not discovered`;
+- `local module requires both module and project for dependency substitution`.
+
+- [ ] **Step 5: Verify task 3 coverage**
+
+Run:
+
+```bash
+rg -n "minestom-server|distribution bundle|build\\.task|build\\.artifact|grounds\\.agones|plugin-agones-minestom" build
+```
+
+Expected: command exits `0` and shows hits in all four modified Build pages.
+
+## Task 4: Update Agones Minestom Docs
+
+**Files:**
+- Modify: `reference/plugins/agones/minestom.mdx`
+
+- [ ] **Step 1: Make provider-based integration primary**
+
+Rewrite the top of `reference/plugins/agones/minestom.mdx` so it:
+
+- says `plugin-agones-minestom` `0.6.0` or newer exposes `grounds.agones`;
+- uses `runtimeOnly("gg.grounds:plugin-agones-minestom:<version>")`;
+- shows runtime composition with `discoverProviders().useProvider("grounds.agones")`;
+- explains that the runtime calls `install`, `start`, and `stop`.
+
+- [ ] **Step 2: Keep direct lifecycle as low-level only**
+
+Move direct `GroundsPluginAgones().enable()` / `disable()` instructions into a later section named `Low-level direct usage`.
+
+Open that section with:
+
+```mdx
+<Warning>
+Use direct lifecycle calls only when you are embedding the Agones module without
+`grounds-minestom-runtime`. Runtime-based servers should select the provider
+instead.
+</Warning>
+```
+
+- [ ] **Step 3: Verify Agones page no longer starts with direct lifecycle**
+
+Run:
+
+```bash
+sed -n '1,120p' reference/plugins/agones/minestom.mdx
+```
+
+Expected: top section describes provider-based runtime integration, not `enable()`.
+
+## Task 5: Validate, Commit, Push, And Open PR
+
+**Files:**
+- All files changed in Tasks 1-4.
+
+- [ ] **Step 1: Run static checks**
+
+Run:
+
+```bash
+git diff --check
+rg -n "TODO|TBD|FIXME|placeholder" reference build docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
+```
+
+Expected: `git diff --check` exits `0`. The placeholder scan exits non-zero or only reports intentional historical text outside changed files.
+
+- [ ] **Step 2: Validate navigation references**
+
+Run:
+
+```bash
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+cfg = json.loads(Path("docs.json").read_text())
+missing = []
+
+def walk(node):
+    if isinstance(node, str):
+        p = Path(node + ".mdx")
+        if not p.exists():
+            missing.append(str(p))
+    elif isinstance(node, list):
+        for item in node:
+            walk(item)
+    elif isinstance(node, dict):
+        if "pages" in node:
+            walk(node["pages"])
+
+walk(cfg["navigation"]["tabs"])
+if missing:
+    raise SystemExit("missing docs.json pages: " + ", ".join(missing))
+PY
+```
+
+Expected: command exits `0`.
+
+- [ ] **Step 3: Run Mintlify validation if available**
+
+Run:
+
+```bash
+if command -v mint >/dev/null 2>&1; then mint broken-links; else echo "mint CLI not installed; relying on docs CI"; fi
+```
+
+Expected: either Mintlify validation passes or the command clearly reports that local Mintlify is unavailable.
+
+- [ ] **Step 4: Commit docs changes**
+
+Run:
+
+```bash
+git add docs.json reference/development build reference/plugins/agones/minestom.mdx docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
+git commit -S -m "docs: document runtime module workflows"
+```
+
+Expected: signed commit succeeds.
+
+- [ ] **Step 5: Push and open PR**
+
+Run:
+
+```bash
+git push -u origin docs/runtime-feature-docs-plan
+gh pr create --draft --title "docs: document runtime module workflows" --body-file /tmp/grounds-docs-runtime-feature-pr.md
+```
+
+Use the repository PR template if present. If there is no PR template, include:
+
+```md
+## Summary
+- Document JVM service registry usage as a standalone development library reference
+- Add Minestom runtime module, composition, and local module workflow docs
+- Update Forge/CLI build workflow docs and Agones Minestom provider integration
+
+## Testing
+- [ ] git diff --check
+- [ ] docs.json navigation reference check
+- [ ] Mintlify validation or local CLI availability note
+```
+
+Expected: draft PR exists on `groundsgg/docs`.

--- a/docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
+++ b/docs/superpowers/plans/2026-06-17-runtime-feature-docs.md
@@ -263,9 +263,7 @@ Modify `build/local-plugin-workspaces.mdx`:
 - add a Minestom module example:
 
 ```bash
-grounds workspace add plugin-agones ~/grounds/plugin-agones \
-  --variant minestom \
-  --build './gradlew :minestom:build'
+grounds workspace add plugin-agones ~/grounds/plugin-agones --variant minestom
 ```
 
 - describe optional `workspace.yaml` fields:

--- a/docs/superpowers/specs/2026-06-17-runtime-feature-docs-design.md
+++ b/docs/superpowers/specs/2026-06-17-runtime-feature-docs-design.md
@@ -1,0 +1,134 @@
+# Runtime Feature Docs Design
+
+## Context
+
+Grounds now has several related runtime features that are implemented across different repositories:
+
+- `library-jvm-modules` provides typed service keys, service registry access, module descriptors, graph validation, and `ServiceLoader` discovery primitives.
+- `grounds-minestom-runtime` provides the Grounds-specific Minestom runtime API, module lifecycle, explicit provider selection, server type filtering, and example runtime composition.
+- `plugin-agones` exposes a Minestom `GroundsModuleProvider` for `grounds.agones`.
+- `grounds-cli` and `grounds-forge` support `minestom-server` pushes as distribution tar uploads, including local Minestom module substitution from workspace mappings.
+
+The canonical public documentation lives in `groundsgg/docs`, a Mintlify site. The new docs should be added there, not only in the individual implementation repositories.
+
+## Goals
+
+- Document the service registry as its own reusable JVM module concept.
+- Document the Minestom runtime as a development API, not as a single plugin.
+- Document Forge and CLI behavior for Minestom distribution pushes.
+- Update Agones Minestom docs to the provider-based runtime model.
+- Keep workflow pages under `Build` and API/reference pages under `Reference`.
+- Reuse the existing Mintlify style and navigation structure.
+
+## Non-Goals
+
+- Do not document unreleased future runtime services as shipped features.
+- Do not replace Javadoc or Dokka output.
+- Do not move implementation docs out of their repos in this change.
+- Do not document a runtime plugin folder model. Minestom servers are built as immutable distributions.
+
+## Recommended Documentation Structure
+
+### Service Registry
+
+Add `reference/development/jvm-modules/service-registry.mdx`.
+
+This page documents `library-jvm-modules` independently from Minestom:
+
+- when to use type-first service access;
+- `serviceKey<T>()`;
+- `qualifiedServiceKey<T>(...)`;
+- `ServiceRegistry.register`, `get`, `require`, and `contains`;
+- non-reified class-based access for Java-compatible or reflection-heavy call sites;
+- module descriptors with `requires`, `provides`, and `dependsOn`;
+- guidance that qualified keys should be defined once by the service owner and not created inline at call sites.
+
+Navigation should add a `JVM modules` group under `Reference > Convention plugins` or a new adjacent `Development libraries` group. The preferred placement is a new `Development libraries` group because the service registry is not a Gradle convention plugin.
+
+### Minestom Runtime
+
+Add a new group under `Reference > Development libraries`:
+
+```text
+reference/development/minestom-runtime/index.mdx
+reference/development/minestom-runtime/modules.mdx
+reference/development/minestom-runtime/composition.mdx
+reference/development/minestom-runtime/local-modules.mdx
+```
+
+Suggested page responsibilities:
+
+- `index.mdx`: concept overview, build-time composition, immutable server distributions, relation to Minestom, and when to use this runtime.
+- `modules.mdx`: `GroundsModule`, `GroundsModuleProvider`, `ModuleDescriptor`, lifecycle hooks, server type compatibility, service contracts, and provider metadata.
+- `composition.mdx`: `GroundsServer.builder()`, `discoverProviders()`, `useProvider("grounds.agones")`, direct `use(...)`, startup logs, validation failures, and example runtime composition.
+- `local-modules.mdx`: how `grounds.yaml` module entries and CLI workspace mappings let developers replace release Minestom modules with local builds.
+
+This keeps API concepts separate from push workflow details while still linking to the Build pages for end-to-end pushing.
+
+### Forge And CLI Build Workflow
+
+Update existing Build pages instead of creating a parallel Minestom section:
+
+- `build/manifest.mdx`: add `type: minestom-server`, `baseImage: minestom`, `build.task`, `build.artifact`, and `modules` fields.
+- `build/cli/push.mdx`: document that `grounds push` handles `minestom-server` manifests directly, builds the configured distribution task, normalizes/uploads the tar artifact, and supports `--local` and `--with-local` module substitutions.
+- `build/local-plugin-workspaces.mdx`: generalize wording from "plugin overrides" to "plugin and module workspace overrides" where needed, and add a Minestom example mapping for `plugin-agones` with variant `minestom`.
+- `build/troubleshooting.mdx`: add Minestom-specific failures such as uploading a JAR instead of a tar distribution, missing distribution artifact, and requesting a module provider that is not on the runtime classpath.
+
+### Agones Minestom
+
+Update `reference/plugins/agones/minestom.mdx`.
+
+The page currently describes direct manual `GroundsPluginAgones.enable()` and `disable()` usage. It should move the provider-based runtime model to the top:
+
+- require `plugin-agones-minestom` `0.6.0` or newer for `GroundsModuleProvider` discovery;
+- show `runtimeOnly("gg.grounds:plugin-agones-minestom:<version>")`;
+- show `GroundsServer.builder().discoverProviders().useProvider("grounds.agones")`;
+- explain that the runtime owns lifecycle calls;
+- keep direct manual `GroundsPluginAgones` usage as a low-level/legacy section if still supported by the API.
+
+## Navigation Design
+
+Update `docs.json`:
+
+- Under `Reference`, add a new group named `Development libraries`.
+- Place `reference/development/jvm-modules/service-registry` in that group.
+- Place the Minestom runtime pages in the same group.
+- Keep `reference/plugins/agones/minestom` under `Plugins SDK > Agones Integration`.
+- Keep Forge/CLI pages in the existing `Build` tab.
+
+This avoids mixing workflow instructions with library reference material.
+
+## Source Of Truth
+
+Use current implementation code as source of truth:
+
+- `library-jvm-modules` for service registry APIs and naming.
+- `grounds-minestom-runtime` for runtime API, builder methods, environment parsing, examples, and module composition behavior.
+- `plugin-agones` for the Minestom provider ID and version requirements.
+- `grounds-cli` and `grounds-forge` for `grounds.yaml`, upload artifact shape, workspace mapping, and push behavior.
+
+When examples mention versions, use released versions known to contain the documented feature. For Agones Minestom provider discovery, use `0.6.0` or newer.
+
+## Testing And Validation
+
+Validate the documentation change with:
+
+- Mintlify navigation validation if a local command is available.
+- Link/path checks by inspecting `docs.json` references and created files.
+- Repository search for stale Minestom wording, especially old `enable()`/`disable()` first-path instructions.
+- A final `git diff --check`.
+
+If Mintlify CLI is not installed locally, document that limitation in the PR and rely on docs repository CI.
+
+## Open Decisions
+
+- Whether to keep direct `GroundsPluginAgones.enable()` documentation as a legacy section or remove it entirely if the public API should now be runtime-only.
+- Whether to add a short `build/minestom-distributions.mdx` workflow page later if `build/manifest.mdx` and `build/cli/push.mdx` become too large.
+
+## Acceptance Criteria
+
+- Developers can find service registry docs without reading Minestom runtime docs.
+- Developers can understand how to write a Minestom runtime module and expose services.
+- Developers can understand how a Minestom server selects provider-backed modules.
+- Developers can push a Minestom server distribution through Grounds.
+- Agones Minestom docs no longer recommend the old direct lifecycle path as the primary integration.

--- a/reference/development/jvm-modules/service-registry.mdx
+++ b/reference/development/jvm-modules/service-registry.mdx
@@ -1,0 +1,152 @@
+---
+title: "Service Registry"
+description: "Publish and consume typed JVM module services without string lookups at call sites."
+---
+
+The Grounds JVM module library uses typed service keys so modules can publish stable service
+contracts and other modules can consume them without looking up raw strings.
+
+Use the service registry when modules in the same JVM need to share stable interfaces, such as a
+matchmaking service, player service, config service, or NATS client. The registry is not a remote
+service discovery system and it does not create classloader isolation.
+
+## Type-first access
+
+Use type-first access when there is one implementation for a service contract.
+
+```kotlin
+import gg.grounds.modules.register
+import gg.grounds.modules.require
+import gg.grounds.modules.core.DefaultServiceRegistry
+
+interface MyService {
+    fun status(): String
+}
+
+class DefaultMyService : MyService {
+    override fun status(): String = "ready"
+}
+
+val registry = DefaultServiceRegistry()
+
+registry.register<MyService>(DefaultMyService())
+
+val service = registry.require<MyService>()
+```
+
+The default `serviceKey<T>()` uses the Kotlin type as the key. That keeps normal call sites free
+from string identifiers.
+
+## Class-based access
+
+Use class-based access from non-reified code, Java-facing adapters, or code paths that already carry
+a `KClass`.
+
+```kotlin
+registry.register(MyService::class, DefaultMyService())
+
+val service = registry.require(MyService::class)
+```
+
+The class-based overloads create the same default service key as `serviceKey<MyService>()`.
+
+## Optional services
+
+Use `get` or `contains` when a service is optional.
+
+```kotlin
+val service = registry.get<MyService>()
+
+if (registry.contains<MyService>()) {
+    // Enable integration that depends on MyService.
+}
+```
+
+Use `require` for mandatory dependencies. It throws a missing-service error when no implementation
+is registered.
+
+## Qualified keys
+
+Use qualified keys only when the same service contract has multiple implementations and consumers
+must choose one explicitly.
+
+```kotlin
+import gg.grounds.modules.qualifiedServiceKey
+
+interface NatsClient
+
+object NatsServiceKeys {
+    val Public = qualifiedServiceKey<NatsClient>("grounds.nats.public")
+    val Internal = qualifiedServiceKey<NatsClient>("grounds.nats.internal")
+}
+```
+
+Register and read the qualified keys explicitly:
+
+```kotlin
+registry.register(NatsServiceKeys.Public, publicNats)
+registry.register(NatsServiceKeys.Internal, internalNats)
+
+val internalNats = registry.require(NatsServiceKeys.Internal)
+```
+
+<Warning>
+Do not create qualified keys inline at call sites. Define them once in the module API that owns the
+service contract, then reuse those constants everywhere.
+</Warning>
+
+## Module descriptors
+
+Use the same service keys in module descriptors. `requires` and `provides` describe service
+contracts. `dependsOn` describes module startup order.
+
+```kotlin
+import gg.grounds.modules.ModuleDescriptor
+import gg.grounds.modules.ModuleProvider
+import gg.grounds.modules.serviceKey
+
+class MatchmakingModuleProvider : ModuleProvider<MatchmakingModule> {
+    override val descriptor =
+        ModuleDescriptor(
+            id = "grounds.matchmaking",
+            version = "1.0.0",
+            requires = setOf(NatsServiceKeys.Internal),
+            provides = setOf(serviceKey<MatchmakingService>()),
+            dependsOn = setOf("grounds.config"),
+        )
+
+    override fun create(): MatchmakingModule = MatchmakingModule()
+}
+```
+
+Use this split intentionally:
+
+| Field | Use it for |
+| --- | --- |
+| `requires` | Services that must exist before this module can run. |
+| `provides` | Services this module promises to register. |
+| `dependsOn` | Modules that must start before this module even when no service contract exists. |
+
+## Failure behavior
+
+The default registry rejects duplicate registrations for the same service key. `require` fails when
+the requested service is missing.
+
+<AccordionGroup>
+<Accordion title="Duplicate service">
+Registering the same key twice throws a duplicate-service error. If two implementations of the same
+contract need to exist at once, use qualified keys.
+</Accordion>
+
+<Accordion title="Missing service">
+`registry.require<MyService>()` throws when `MyService` is not registered. Prefer `require` for
+mandatory module dependencies so failures happen during startup instead of later gameplay.
+</Accordion>
+</AccordionGroup>
+
+## Next steps
+
+- Read [Minestom Runtime modules](/reference/development/minestom-runtime/modules) to see how
+  Grounds runtime modules declare service contracts.
+- Read [Minestom Runtime composition](/reference/development/minestom-runtime/composition) to see
+  how provider-backed modules are selected at startup.

--- a/reference/development/minestom-runtime/composition.mdx
+++ b/reference/development/minestom-runtime/composition.mdx
@@ -1,0 +1,148 @@
+---
+title: "Runtime Composition"
+description: "Discover and select provider-backed Grounds modules in a Minestom server."
+---
+
+Runtime composition is the point where your Minestom application chooses which modules are active.
+Classpath discovery finds available providers, but only selected providers are installed.
+
+## Build a server
+
+Use `GroundsServer.builder()` from your application entrypoint.
+
+```kotlin
+import gg.grounds.runtime.core.GroundsServer
+
+fun main() {
+    GroundsServer.builder()
+        .discoverProviders()
+        .useProvider("grounds.agones")
+        .start()
+}
+```
+
+`start()` calls `build()` and then starts Minestom. Use `build()` when tests need to inspect the
+composition without starting the server process.
+
+## Discover providers
+
+`discoverProviders()` scans the current thread context classloader with Java `ServiceLoader`.
+
+```kotlin
+GroundsServer.builder()
+    .discoverProviders()
+```
+
+The runtime logs the discovered provider IDs and versions. If nothing is found, it logs that no
+providers were discovered.
+
+<Note>
+Discovery does not activate every provider. You still choose each provider explicitly with
+`useProvider`.
+</Note>
+
+## Select discovered providers
+
+Select a provider by stable module ID:
+
+```kotlin
+GroundsServer.builder()
+    .discoverProviders()
+    .useProvider("grounds.agones")
+    .build()
+```
+
+The ID must match a discovered `GroundsModuleProvider.id`. If the ID is missing, build fails before
+Minestom starts:
+
+```text
+Grounds module provider grounds.agones was requested but not discovered. Available providers: none
+```
+
+If multiple providers expose the same ID, build fails as ambiguous. Keep provider IDs globally
+stable and unique.
+
+## Use direct providers
+
+Use `use(provider)` when the provider is created directly by your runtime application instead of
+through `ServiceLoader`.
+
+```kotlin
+GroundsServer.builder()
+    .use(ExampleMinigameModuleProvider())
+    .build()
+```
+
+Direct providers still participate in descriptor validation, service dependency ordering, and
+server type filtering.
+
+## Use direct modules
+
+Use `use(module)` for simple modules that do not need descriptor metadata.
+
+```kotlin
+GroundsServer.builder()
+    .use(DebugOverlayModule())
+    .build()
+```
+
+Direct modules are installed after provider-backed modules. Prefer providers for reusable modules
+because descriptors make dependencies and service contracts visible before startup.
+
+## Configure runtime environment
+
+By default, the runtime reads environment variables:
+
+| Variable | Default | Values |
+| --- | --- | --- |
+| `GROUNDS_SERVER_TYPE` | `minigame` | `lobby`, `minigame` |
+| `GROUNDS_ENV` | `dev` | `dev`, `test`, `prod` |
+| `GROUNDS_BIND_HOST` | `0.0.0.0` | Any bind host |
+| `GROUNDS_BIND_PORT` | `25565` | Any integer port |
+
+Tests can pass explicit config:
+
+```kotlin
+import gg.grounds.runtime.RuntimeEnvironment
+import gg.grounds.runtime.ServerType
+import gg.grounds.runtime.core.RuntimeConfig
+
+GroundsServer.builder()
+    .config(RuntimeConfig(serverType = ServerType.MINIGAME, environment = RuntimeEnvironment.TEST))
+    .use(ExampleMinigameModuleProvider())
+    .build()
+```
+
+## Startup behavior
+
+When the runtime starts, it:
+
+1. resolves selected discovered providers;
+2. validates module descriptors and service contracts;
+3. sorts provider-backed modules by dependencies;
+4. initializes Minestom;
+5. calls `install(ctx)` on every selected module;
+6. starts Minestom on the configured host and port;
+7. calls `start()` on every selected module.
+
+Shutdown reverses the module order, then runs registered shutdown hooks and stops Minestom cleanly.
+
+## Example with Agones and a game module
+
+```kotlin
+internal fun buildExampleServer(): GroundsServer =
+    GroundsServer.builder()
+        .discoverProviders()
+        .useProvider("grounds.agones")
+        .use(ExampleMinigameModuleProvider())
+        .build()
+```
+
+This composition discovers `plugin-agones-minestom` from the runtime classpath, selects its
+`grounds.agones` provider, and also installs a local minigame module provider.
+
+## Related docs
+
+- [Runtime modules](/reference/development/minestom-runtime/modules)
+- [Local modules](/reference/development/minestom-runtime/local-modules)
+- [Agones Minestom integration](/reference/plugins/agones/minestom)

--- a/reference/development/minestom-runtime/index.mdx
+++ b/reference/development/minestom-runtime/index.mdx
@@ -1,0 +1,110 @@
+---
+title: "Minestom Runtime"
+description: "Build Minestom lobby and minigame servers from explicit Grounds runtime modules."
+---
+
+`grounds-minestom-runtime` is the process-level runtime for Minestom-based Grounds servers. It lets
+you compose a lobby or minigame from normal Gradle dependencies, select explicit runtime modules,
+and push the resulting distribution through Grounds.
+
+Minestom does not have a Paper-style plugin folder. A Minestom server is a JVM application that
+embeds Minestom and every module it needs. Grounds follows that model: build the server at compile
+time, publish one immutable distribution, then let Forge build and deploy the image.
+
+<Note>
+The runtime is not a hot plugin system. It discovers providers from the application classpath and
+starts only the providers your server selects.
+</Note>
+
+## What the runtime provides
+
+- module lifecycle hooks with `install`, `start`, and `stop`;
+- `GroundsServerContext` with server type, runtime environment, shutdown hooks, and typed services;
+- provider discovery through Java `ServiceLoader`;
+- explicit provider selection through `useProvider("module.id")`;
+- module descriptor validation, service dependency ordering, and server type filtering;
+- Minestom bootstrap and clean shutdown orchestration.
+
+## When to use it
+
+Use the runtime for Minestom servers that need reusable Grounds integrations such as Agones, config,
+permissions, matchmaking, or shared services.
+
+Do not use it when you only need a small standalone Minestom experiment with no reusable modules.
+Plain Minestom code still works; the runtime exists to make composed Grounds servers reproducible.
+
+## Typical shape
+
+```text
+my-minigame/
+  settings.gradle.kts
+  build.gradle.kts
+  grounds.yaml
+  server/
+    build.gradle.kts
+    src/main/kotlin/example/Main.kt
+```
+
+The Gradle app depends on released module artifacts:
+
+```kotlin server/build.gradle.kts
+dependencies {
+    implementation("gg.grounds:grounds-minestom-runtime-runtime-core:<version>")
+    runtimeOnly("gg.grounds:plugin-agones-minestom:0.6.0")
+}
+```
+
+The server entrypoint selects the modules it wants:
+
+```kotlin
+import gg.grounds.runtime.core.GroundsServer
+
+fun main() {
+    GroundsServer.builder()
+        .discoverProviders()
+        .useProvider("grounds.agones")
+        .start()
+}
+```
+
+The project pushes a distribution tar:
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :server:distTar
+  artifact: server/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+## Start here
+
+<CardGroup cols={2}>
+<Card title="Runtime modules" icon="puzzle-piece" href="/reference/development/minestom-runtime/modules">
+  Define `GroundsModule` and `GroundsModuleProvider` implementations with descriptors and typed
+  service contracts.
+</Card>
+
+<Card title="Runtime composition" icon="diagram-project" href="/reference/development/minestom-runtime/composition">
+  Discover providers, select module IDs, and understand validation and startup behavior.
+</Card>
+
+<Card title="Local modules" icon="code-branch" href="/reference/development/minestom-runtime/local-modules">
+  Replace release module dependencies with local repositories during `grounds push`.
+</Card>
+
+<Card title="Manifest reference" icon="file-code" href="/build/manifest#minestom-server-manifests">
+  See the `grounds.yaml` fields used for Minestom distribution pushes.
+</Card>
+</CardGroup>
+
+## Related docs
+
+- [Service Registry](/reference/development/jvm-modules/service-registry)
+- [grounds push](/build/cli/push)
+- [Agones Minestom integration](/reference/plugins/agones/minestom)

--- a/reference/development/minestom-runtime/local-modules.mdx
+++ b/reference/development/minestom-runtime/local-modules.mdx
@@ -1,0 +1,145 @@
+---
+title: "Local Minestom Modules"
+description: "Replace release Minestom module dependencies with local repositories during grounds push."
+---
+
+Local Minestom module substitution lets you keep release module sources in `grounds.yaml` while
+testing local changes from sibling repositories.
+
+Use this when your server runtime is in one repository and a runtime module, such as
+`plugin-agones:minestom`, is in another repository.
+
+## Manifest modules
+
+A Minestom server manifest declares the release defaults that every developer and CI runner can
+resolve.
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :examples:minigame-agones:distTar
+  artifact: examples/minigame-agones/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+`modules` is CLI composition metadata. It tells `grounds push` which release modules can be
+replaced locally. Your Gradle dependencies still define the actual runtime classpath.
+
+<Tip>
+Keep `source` pinned to a release in shared manifests. Put local paths in `workspace.yaml` so the
+manifest stays portable.
+</Tip>
+
+## Add a local module mapping
+
+Add a local repository mapping for the Minestom variant:
+
+```bash
+grounds workspace add plugin-agones ~/grounds/plugin-agones --variant minestom
+```
+
+The mapping is stored in your local `workspace.yaml`, not in the project manifest.
+
+## Push with local modules
+
+Use `--local` for selected modules:
+
+```bash
+grounds push --local plugin-agones
+```
+
+Use `--with-local` for every enabled workspace entry that matches a `modules` entry:
+
+```bash
+grounds push --with-local
+```
+
+For Minestom pushes, the CLI:
+
+1. loads `grounds.yaml`;
+2. resolves selected local module mappings from `workspace.yaml`;
+3. writes a temporary Gradle composite-build init script;
+4. runs the configured `build.task`, such as `:examples:minigame-agones:distTar`;
+5. finds the configured `build.artifact`;
+6. normalizes the distribution tar;
+7. uploads the normalized distribution to Forge.
+
+## Effective source table
+
+When local module resolution runs, the CLI prints the effective source table:
+
+```text
+Bundle sources:
+ID              Variant   Effective   Value
+plugin-agones   minestom  local       /home/alice/grounds/plugin-agones
+```
+
+Use this table as the confirmation step before reading build logs. It shows which modules came from
+local repositories and which modules stayed on release sources.
+
+## Explicit dependency substitution
+
+Gradle composite builds often substitute dependencies automatically when the local included build
+publishes the same module coordinates as the release dependency.
+
+When a repository needs explicit substitution, add `module` and `project` to the Minestom variant in
+`workspace.yaml`:
+
+```yaml
+repos:
+  plugin-agones:
+    path: /home/alice/grounds/plugin-agones
+    variants:
+      minestom:
+        enabled: true
+        module: gg.grounds:plugin-agones-minestom
+        project: :minestom
+```
+
+The CLI then writes a Gradle init script equivalent to:
+
+```kotlin
+settingsEvaluated {
+    includeBuild("/home/alice/grounds/plugin-agones") {
+        dependencySubstitution {
+            substitute(module("gg.grounds:plugin-agones-minestom")).using(project(":minestom"))
+        }
+    }
+}
+```
+
+<Warning>
+If `module` is set, `project` must also be set. If only one field is present, the CLI fails before
+running Gradle.
+</Warning>
+
+<Note>
+For Minestom module substitution, the app's Gradle distribution task builds against the included
+local repository. The workspace `artifact` and `build` fields are used for plugin artifact
+overrides and are not the source of truth for the Minestom runtime classpath.
+</Note>
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="The release dependency is still used">
+Check `grounds workspace list` and confirm the `plugin-agones` `minestom` variant is enabled. Then
+run `grounds push --with-local` or `grounds push --local plugin-agones`.
+</Accordion>
+
+<Accordion title="The selected local module is not in grounds.yaml">
+`--local <id>` must match an entry under `modules`. Add the module to `grounds.yaml` or use the
+correct module ID.
+</Accordion>
+</AccordionGroup>
+
+## Related docs
+
+- [Work with local plugin workspaces](/build/local-plugin-workspaces)
+- [grounds push](/build/cli/push)
+- [Manifest reference](/build/manifest#minestom-server-manifests)

--- a/reference/development/minestom-runtime/modules.mdx
+++ b/reference/development/minestom-runtime/modules.mdx
@@ -1,0 +1,162 @@
+---
+title: "Runtime Modules"
+description: "Write Grounds modules for Minestom servers with descriptors, lifecycle hooks, and typed service contracts."
+---
+
+A Minestom runtime module is a JVM object that is installed and started by `GroundsServer`. Modules
+use descriptors to declare metadata, module dependencies, provided services, and required services.
+
+## Module lifecycle
+
+Implement `GroundsModule` for the runtime behavior.
+
+```kotlin
+import gg.grounds.runtime.GroundsModule
+import gg.grounds.runtime.GroundsServerContext
+
+class MatchmakingModule : GroundsModule {
+    override val id: String = "grounds.matchmaking"
+
+    override fun install(ctx: GroundsServerContext) {
+        // Register event handlers, services, and shutdown hooks here.
+    }
+
+    override fun start() {
+        // Start background work after Minestom has started.
+    }
+
+    override fun stop() {
+        // Stop background work and release resources.
+    }
+}
+```
+
+Lifecycle order:
+
+1. The runtime validates selected providers.
+2. The runtime creates module instances.
+3. `install(ctx)` runs before Minestom starts accepting players.
+4. Minestom starts.
+5. `start()` runs in module order.
+6. During shutdown, `stop()` runs in reverse order.
+
+## Server context
+
+`GroundsServerContext` gives modules runtime information and shared module services.
+
+```kotlin
+override fun install(ctx: GroundsServerContext) {
+    val serverType = ctx.serverType
+    val environment = ctx.environment
+    val events = ctx.eventNode("grounds-matchmaking")
+
+    ctx.onShutdown {
+        // Cleanup that should run when the runtime stops.
+    }
+}
+```
+
+| Property or method | Use it for |
+| --- | --- |
+| `serverType` | Branching behavior between `LOBBY` and `MINIGAME`. |
+| `environment` | Branching behavior between `DEV`, `TEST`, and `PROD`. |
+| `services` | Registering and consuming typed services. |
+| `eventNode(name)` | Creating Minestom event nodes owned by your module. |
+| `onShutdown(action)` | Registering cleanup actions with the runtime. |
+
+## Module providers
+
+Use a `GroundsModuleProvider` when a module should be discoverable from the classpath.
+
+```kotlin
+import gg.grounds.modules.ModuleDescriptor
+import gg.grounds.modules.serviceKey
+import gg.grounds.runtime.GroundsModule
+import gg.grounds.runtime.GroundsModuleProvider
+import gg.grounds.runtime.ServerType
+
+class MatchmakingModuleProvider : GroundsModuleProvider {
+    override val id: String = "grounds.matchmaking"
+    override val version: String = "1.0.0"
+    override val serverTypes: Set<ServerType> = setOf(ServerType.MINIGAME)
+    override val descriptor: ModuleDescriptor =
+        ModuleDescriptor(
+            id = id,
+            version = version,
+            requires = setOf(serviceKey<PlayerService>()),
+            provides = setOf(serviceKey<MatchmakingService>()),
+        )
+
+    override fun create(): GroundsModule = MatchmakingModule()
+}
+```
+
+The provider is the runtime-facing factory. Keep module construction cheap and defer I/O to
+`install` or `start`.
+
+## ServiceLoader registration
+
+Provider-backed modules are discovered through Java `ServiceLoader`. Add a provider file to the
+module artifact:
+
+```text META-INF/services/gg.grounds.runtime.GroundsModuleProvider
+com.example.MatchmakingModuleProvider
+```
+
+After the artifact is on the runtime classpath, `GroundsServer.builder().discoverProviders()` can
+discover it.
+
+## Server type compatibility
+
+`serverTypes` controls where the provider is valid.
+
+```kotlin
+override val serverTypes: Set<ServerType> = setOf(ServerType.MINIGAME)
+```
+
+Use `ServerType.MINIGAME` for game servers and `ServerType.LOBBY` for lobby-only modules. Omit the
+override only when the module works in every server type.
+
+## Service contracts
+
+Use `requires` and `provides` for module-to-module service contracts.
+
+```kotlin
+override val descriptor =
+    ModuleDescriptor(
+        id = id,
+        version = version,
+        requires = setOf(serviceKey<PlayerService>()),
+        provides = setOf(serviceKey<MatchmakingService>()),
+    )
+```
+
+Inside `install`, register the services your descriptor provides:
+
+```kotlin
+import gg.grounds.modules.register
+
+override fun install(ctx: GroundsServerContext) {
+    ctx.services.register<MatchmakingService>(DefaultMatchmakingService())
+}
+```
+
+Consumers can require services by type:
+
+```kotlin
+import gg.grounds.modules.require
+
+override fun install(ctx: GroundsServerContext) {
+    val players = ctx.services.require<PlayerService>()
+}
+```
+
+<Tip>
+Use `dependsOn` for startup order that is not represented by a service contract. Use `requires` and
+`provides` when a module actually consumes or publishes a typed service.
+</Tip>
+
+## Next steps
+
+- Read [Service Registry](/reference/development/jvm-modules/service-registry) for key and registry details.
+- Read [Runtime composition](/reference/development/minestom-runtime/composition) to select provider-backed modules in a server.

--- a/reference/plugins/agones/minestom.mdx
+++ b/reference/plugins/agones/minestom.mdx
@@ -1,33 +1,32 @@
 ---
 title: "Minestom"
-description: "Embed plugin-agones-minestom as a library in your Minestom gameserver to sync Agones state"
+description: "Select the Agones runtime module in Minestom servers to sync Agones state from player activity."
 ---
 
-Use the Minestom module of `plugin-agones` when your gamemode runs on Minestom. Unlike the Paper
-build, Minestom has no plugin loader, so this module ships as a library that you embed and start
-explicitly from your server entrypoint.
+Use `plugin-agones-minestom` when your gamemode or lobby runs on Minestom and should report
+Agones state from player activity. In runtime-based servers, Agones is a provider-backed Grounds
+module selected by module ID.
 
-Once started, the library syncs Agones state from Minestom's player events the same way the Paper
-build does: the first player switches the gameserver to `Allocated`, the last one returning to
-`Ready`.
+Once started, the module syncs Agones state from Minestom player events: the first player switches
+the gameserver to `Allocated`, and the last player leaving switches it back to `Ready`.
+
+<Info>
+`plugin-agones-minestom` `0.6.0` and newer exposes a `GroundsModuleProvider` with ID
+`grounds.agones`.
+</Info>
 
 ## Requirements
 
 Your Minestom pod must run with an Agones sidecar exposing the SDK on `http://localhost:9358`. The
-Grounds container images configure this by default.
+Grounds Minestom image path configures this through the Agones-managed workload.
 
-<Info>
-The module targets Minestom `2026.03.03-1.21.11` and newer. It uses an internal coroutine scope for
-the sidecar calls, so you do not need to provide an executor.
-</Info>
+Your runtime application must use `grounds-minestom-runtime` and include the Agones Minestom module
+on the runtime classpath.
 
-## Add the Dependency
+## Add the dependency
 
 The module is published to the `groundsgg` GitHub Packages Maven registry as
 `gg.grounds:plugin-agones-minestom`.
-
-<Tabs>
-<Tab title="Gradle Kotlin DSL">
 
 ```kotlin build.gradle.kts
 repositories {
@@ -41,42 +40,98 @@ repositories {
 }
 
 dependencies {
-    implementation("gg.grounds:plugin-agones-minestom:<version>")
+    runtimeOnly("gg.grounds:plugin-agones-minestom:0.6.0")
 }
 ```
-
-</Tab>
-
-<Tab title="Gradle Groovy DSL">
-
-```groovy build.gradle
-repositories {
-    maven {
-        url "https://maven.pkg.github.com/groundsgg/plugin-agones"
-        credentials {
-            username = providers.gradleProperty('github.user').get()
-            password = providers.gradleProperty('github.token').get()
-        }
-    }
-}
-
-dependencies {
-    implementation "gg.grounds:plugin-agones-minestom:<version>"
-}
-```
-
-</Tab>
-</Tabs>
 
 <Warning>
 GitHub Packages requires authentication even for public artifacts. Configure `github.user` and
-`github.token` in your `~/.gradle/gradle.properties` or through environment variables.
+`github.token` in `~/.gradle/gradle.properties` or through environment variables.
 </Warning>
 
-## Start and Stop From Your Entrypoint
+## Select the provider
 
-`GroundsPluginAgones` is the single public entry point. Instantiate it once, call `enable()` during
-startup, and `disable()` during shutdown.
+Call `discoverProviders()` and select `grounds.agones` in your runtime composition.
+
+```kotlin
+import gg.grounds.runtime.core.GroundsServer
+
+fun main() {
+    GroundsServer.builder()
+        .discoverProviders()
+        .useProvider("grounds.agones")
+        .start()
+}
+```
+
+The runtime discovers the provider through `META-INF/services`, validates it, creates the module,
+and owns the lifecycle calls:
+
+1. `install(ctx)` registers the player listeners.
+2. `start()` reconciles the initial Agones state and starts the fallback loop.
+3. `stop()` removes listeners, cancels the fallback task, and releases coroutine resources.
+
+<Note>
+Discovery does not activate every provider on the classpath. The runtime starts Agones only when
+you explicitly call `useProvider("grounds.agones")`.
+</Note>
+
+## Manifest example
+
+Keep the release module source in `grounds.yaml` so teammates and CI use the same default.
+
+```yaml grounds.yaml
+name: minigame-agones
+type: minestom-server
+baseImage: minestom
+build:
+  task: :examples:minigame-agones:distTar
+  artifact: examples/minigame-agones/build/distributions/*.tar
+modules:
+  - id: plugin-agones
+    variant: minestom
+    source: github:groundsgg/plugin-agones@v0.6.0:plugin-agones-minestom.jar
+```
+
+`modules` lets the CLI replace `plugin-agones` with a local repository during development. Your
+Gradle dependencies still define the actual runtime classpath.
+
+## State sync semantics
+
+| Event | Resulting Agones state |
+| --- | --- |
+| `PlayerSpawnEvent` when the server had no other players | `Allocated` |
+| `PlayerSpawnEvent` with existing players | No change |
+| `PlayerDisconnectEvent` that leaves the server empty | `Ready` |
+| Fallback tick every 10 seconds | Reconciled from current player count |
+
+The disconnect path schedules its check on the next Minestom tick so that the connection manager's
+player list is already updated when the check runs.
+
+<Note>
+All state transitions go through `AgonesHelper`, which first fetches the gameserver state from the
+sidecar and only sends `Allocate` or `Ready` when it differs. Repeat calls are no-ops.
+</Note>
+
+## Label your GameServer
+
+The Minestom module only handles state sync. For the Velocity proxy to discover your Minestom
+gameserver, you still need to follow the
+[discovery contract](/reference/plugins/agones#gameserver-discovery-contract):
+
+- deploy into the `games` namespace
+- add `grounds/server-type: <lobby|game|match>` to the `GameServer` resource metadata
+- listen on port `25565` in the pod
+
+## Low-level direct usage
+
+<Warning>
+Use direct lifecycle calls only when you are embedding the Agones module without
+`grounds-minestom-runtime`. Runtime-based servers should select the provider instead.
+</Warning>
+
+`GroundsPluginAgones` still exposes direct `enable()` and `disable()` calls for non-runtime
+embeds.
 
 ```kotlin
 import gg.grounds.GroundsPluginAgones
@@ -94,72 +149,35 @@ fun main() {
 }
 ```
 
-<Steps>
-<Step title="Call enable during startup">
-`enable()` reads the current player count, sets the initial Agones state, registers a child
-`EventNode` called `grounds-plugin-agones` on the global event handler, and schedules a 10 second
-fallback reconciliation loop.
+When you use `grounds-minestom-runtime`, do not call `enable()` yourself. The runtime calls
+`install`, `start`, and `stop` through the selected provider.
 
-Calling `enable()` again while the plugin is already running is safe: the existing state is
-disabled first and replaced with a fresh runtime.
-</Step>
-
-<Step title="Call disable during shutdown">
-`disable()` cancels the fallback task, removes the event node from the global handler, and cancels
-the coroutine scope used for sidecar calls. After `disable()`, the instance is reusable with
-another `enable()` call.
-</Step>
-</Steps>
-
-## State Sync Semantics
-
-| Event                                                   | Resulting Agones state |
-|---------------------------------------------------------|------------------------|
-| `PlayerSpawnEvent` when the server had no other players | `Allocated`            |
-| `PlayerSpawnEvent` with existing players                | No change              |
-| `PlayerDisconnectEvent` that leaves the server empty    | `Ready`                |
-| Fallback tick every 10 seconds                          | Reconciled from current player count |
-
-The disconnect path schedules its check on the next Minestom tick so that the connection manager's
-player list is already updated when the check runs.
-
-<Note>
-All state transitions go through `AgonesHelper`, which first fetches the gameserver state from the
-sidecar and only sends `Allocate` or `Ready` when it differs. Repeat calls are no-ops.
-</Note>
-
-## Label Your GameServer
-
-The library only handles state sync. For the Velocity proxy to discover your Minestom gameserver,
-you still need to follow the [discovery contract](/reference/plugins/agones#gameserver-discovery-contract):
-
-- deploy into the `games` namespace
-- add `grounds/server-type: <lobby|game|match>` to the `GameServer` resource metadata
-- listen on port `25565` in the pod
-
-## Failure Modes
+## Failure modes
 
 <AccordionGroup>
-<Accordion title="Agones sidecar unreachable">
-Errors from the sidecar are logged at error level through the class logger. The fallback loop
-keeps retrying every 10 seconds, so a short sidecar outage is recovered automatically without any
-action from your gamemode.
+<Accordion title="Provider was requested but not discovered">
+`Grounds module provider grounds.agones was requested but not discovered` means the runtime selected
+the provider ID, but `plugin-agones-minestom` was not on the runtime classpath or did not expose the
+provider service file. Use `plugin-agones-minestom` `0.6.0` or newer and rebuild the distribution.
 </Accordion>
 
-<Accordion title="enable called twice without a disable in between">
-The second call disables the previous runtime first, so the event node and coroutine scope are
-cleaned up before the new one is created. No duplicate listeners are registered.
+<Accordion title="Agones sidecar unreachable">
+Errors from the sidecar are logged at error level through the class logger. The fallback loop keeps
+retrying every 10 seconds, so a short sidecar outage is recovered automatically without any action
+from your gamemode.
 </Accordion>
 
 <Accordion title="No Agones sidecar at all">
-If your deployment has no Agones sidecar, every sidecar call fails. The plugin continues to run,
-but cannot influence Agones state. In that setup, consider not loading the module at all to keep
-logs clean.
+If your deployment has no Agones sidecar, every sidecar call fails. The module continues to run, but
+cannot influence Agones state. In that setup, do not select `grounds.agones` to keep logs clean.
 </Accordion>
 </AccordionGroup>
 
-## Next Steps
+## Next steps
 
+- Read [Minestom Runtime composition](/reference/development/minestom-runtime/composition) for the
+  provider selection model.
+- Read [Local Minestom Modules](/reference/development/minestom-runtime/local-modules) to test local
+  Agones module changes during `grounds push`.
 - Read the [Velocity page](/reference/plugins/agones/velocity) to see how the proxy picks up this
   gameserver once it reaches a running Agones state.
-- Review the [Agones Integration overview](/reference/plugins/agones) for the cross-platform picture.


### PR DESCRIPTION
# Pull Request

## Description
Document the runtime module workflow for Grounds docs:

- add standalone JVM service registry docs
- add Minestom runtime docs for composition, module providers, and local module replacement
- update Forge/CLI build docs for `minestom-server`
- update Agones Minestom docs for provider-based runtime modules

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues
- None

## Testing
- [ ] Unit tests pass
- [x] Manual testing completed
- [ ] New tests added for new functionality

Manual checks:

- `git diff --check`
- `git diff --cached --check`
- `docs.json` navigation target check
- runtime/provider terminology scan across changed reference and build docs
- GitHub checks: Mintlify deployment, Mintlify link validation, CLA

The docs repo does not include a package manifest or local Mintlify CLI install, so no Mintlify command was available locally.

## Checklist
- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
