### PR TITLE
docs: clarify permission audit actors

### DIFF
--- a/reference/plugins/in-game-permissions/administration.mdx
+++ b/reference/plugins/in-game-permissions/administration.mdx
@@ -77,9 +77,10 @@ Open **Audit** in In-Game Permissions to review Minecraft authorization
 changes. Filter by action family and UTC time range, search by actor, action,
 or target, and page through the newest events first.
 
-Each event records the Portal administrator, action, technical target, time,
-and a non-sensitive change summary. Historical events without an actor display
-as `Unknown`. This history is separate from the Portal Access audit.
+Each event records an actor (a Portal administrator or system actor), action,
+technical target, time, and a non-sensitive change summary. Historical events
+without an actor display as `Unknown`. This history is separate from the Portal
+Access audit.
 
 ## Recommended workflow
 


### PR DESCRIPTION
# Pull Request

## Description

- Clarify that permission audit events may be attributed to a Portal administrator or a system actor.
- Keep this as a focused follow-up to the permission documentation already merged in #43.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] Chore

## Related Issues

- Relates to #43

## Testing

- [ ] Unit tests pass — not applicable for this documentation-only change.
- [ ] Manual testing completed
- [ ] New tests added for new functionality — not applicable for this documentation-only change.

## Checklist

- [x] I have performed a self-review of my own changes
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
