### PR TITLE
docs: update in-game permissions architecture

### DIFF
--- a/reference/plugins/in-game-permissions/administration.mdx
+++ b/reference/plugins/in-game-permissions/administration.mdx
@@ -7,6 +7,12 @@ Use the In-Game Permissions area in Portal to manage authorization for a
 Minecraft network. Portal access authorizes administration only; it never
 becomes a Minecraft role or a player runtime permission.
 
+<Info>
+Project owners and editors can manage their project's permissions. Project
+viewers have read-only access. Production permission administration requires
+separate platform access.
+</Info>
+
 ## Roles
 
 Create a role with a name, optional display metadata, and optional default
@@ -20,6 +26,7 @@ inheritance, for example `moderator` inheriting `member`; Portal rejects cycles.
 | Allow       | Grant `network.chat.moderate` or another capability.             |
 | Deny        | Exclude a capability inherited through another role or wildcard. |
 | Global      | Apply to every server.                                           |
+| Environment | Apply within one deployment environment, such as `stage` or `prod`. |
 | Server type | Apply to all servers of one type, such as `lobby`.               |
 | Server      | Apply to one named server.                                       |
 | Expiry      | End temporary access automatically.                              |
@@ -31,8 +38,8 @@ wins between equally specific candidates.
 
 Search a player to review assigned roles, direct grants, and effective access.
 Use a direct role grant for a reusable exception and a direct permission grant
-for one narrow exception. Both can expire. Verify the selected server type or
-server in effective access before testing in-game.
+for one narrow exception. Both can expire. Verify the selected environment,
+server type, and server in effective access before testing in-game.
 
 ## Assignment sources
 
@@ -63,6 +70,43 @@ reads groups but does not create, rename, or delete them; manage membership in
 Keycloak. An optional mapping expiry supports temporary group-derived access.
 The mapped role supplies the permissions; groups do not receive direct
 permission-node grants.
+
+## Sync production policy into a project
+
+Use **Sync from global** to compare the current production policy with a
+project before changing project data. The preview includes roles, role grants,
+role inheritance, and catalog entries.
+
+<Warning>
+The sync never transfers direct player-to-role assignments or direct player
+permission grants. Review and manage player-specific access inside the target
+project.
+</Warning>
+
+<Steps>
+<Step title="Preview production changes">
+Open **Sync from global**. Portal compares the latest production snapshot with
+the project's current permission state without changing the project.
+</Step>
+
+<Step title="Choose how to resolve conflicts">
+For each conflict, choose **Keep project**, **Use global**, **Skip**, or
+**Remove project** when that action is available. Review additions and removals
+before continuing.
+</Step>
+
+<Step title="Choose whether to include Keycloak mappings">
+Enable **Include Keycloak mappings** only when production group-to-role mappings
+should replace or extend the project mappings. When disabled, existing project
+mappings remain local to the project.
+</Step>
+
+<Step title="Apply the preview">
+Confirm the import. If the project changed after the preview was created,
+Portal rejects the stale preview without changing project data. Create a new
+preview and review it again.
+</Step>
+</Steps>
 
 ## Permission catalog
 
@@ -102,6 +146,7 @@ Confirm its expiry before saving it.
 
 <Step title="Verify effective access">
 Open the player's effective access view for the target server type or server.
-Confirm the resulting roles and patterns before testing in-game.
+Confirm the resulting roles and patterns for the target environment, server
+type, and server before testing in-game.
 </Step>
 </Steps>

--- a/reference/plugins/in-game-permissions/index.mdx
+++ b/reference/plugins/in-game-permissions/index.mdx
@@ -26,9 +26,17 @@ decide what a player may do inside the Minecraft network.
   Publish your workload's permission catalog and manage custom entries.
 </Card>
 <Card title="Understand the infrastructure" icon="diagram-project" href="/reference/plugins/in-game-permissions/infrastructure">
-  Learn why Grounds has global and project-local permission service instances.
+  Learn how production, stage, and project permission environments stay isolated.
 </Card>
 </CardGroup>
+
+## Permission environments
+
+Grounds keeps policy separate between production, stage, and individual
+projects. Production owns the platform's live Minecraft policy. Stage provides
+an isolated pre-production policy environment. Each project owns its local
+policy, which you can initialize or update from production through an explicit
+preview and import workflow.
 
 ## Authorization model
 
@@ -50,7 +58,8 @@ flowchart LR
 |----------------------------------|--------------------------------------------------------------------------------|
 | Keycloak group                   | Read-only identity input that can map to a Minecraft role.                     |
 | Minecraft role                   | Reusable grants; it can inherit another role or be a default role.             |
-| Grant                            | Allow or deny rule at global, server-type, or server scope.                    |
+| Grant                            | Allow or deny rule at global, environment, server-type, or server scope.       |
+| Environment                      | Deployment context such as `stage` or `prod` used for scoped checks.           |
 | Group-to-role mapping            | Assigns a Minecraft role to every player in one Keycloak group; it can expire. |
 | Direct player-to-role assignment | Assigns a reusable role to one player; it can expire.                          |
 | Direct player grant              | Time-limited or permanent exception for one player.                            |
@@ -68,9 +77,9 @@ flowchart LR
 Keycloak groups never map directly to permission nodes: they provide group-to-role
 assignments. A role can then carry allow or deny grants, including inherited
 role grants. Exact patterns such as `network.chat.moderate` and wildcards such
-as `network.chat.*` can match a check. Server scope wins over server-type
-scope, which wins over global scope; a deny wins between equally specific
-candidates.
+as `network.chat.*` can match a check. Server scope wins over server-type scope,
+server-type scope wins over environment scope, and environment scope wins over
+global scope. A deny wins between equally specific candidates.
 
 Once a snapshot expires, a check returns `false` until a valid replacement is
 available. Changing a permission does not disconnect a player automatically.

--- a/reference/plugins/in-game-permissions/infrastructure.mdx
+++ b/reference/plugins/in-game-permissions/infrastructure.mdx
@@ -1,83 +1,114 @@
 ---
 title: "In-Game Permissions Infrastructure"
-description: "Understand global and project-local permission services, identity synchronization, and runtime boundaries."
+description: "Understand production, stage, and project permission environments, identity propagation, and runtime security boundaries."
 ---
 
-Grounds separates global identity coordination from project-local runtime
-authorization. That keeps player checks local to a project while allowing
-identity changes to propagate safely across the platform.
+Grounds separates permission policy between production, stage, and individual
+projects. Each environment owns its policy and identity projection, and each
+runtime connects only to the permission instance assigned to that environment.
 
 ```mermaid
-flowchart LR
+flowchart TB
   keycloak[Keycloak] --> stream[Durable identity stream]
-  stream --> global[Global production instance]
+  stream --> production[Production permission instance]
   stream --> forge[Forge identity relay]
-  portal[Portal] --> proxy[Forge project proxy]
-  proxy --> project[Project instance]
   forge --> broker[Project broker]
-  broker --> project
-  project --> velocity[Velocity]
-  project --> minestom[Minestom]
+  broker --> project[Project permission instance]
+
+  portal[Portal] -->|Production administration| production
+  portal -->|Project administration| proxy[Forge project proxy]
+  proxy --> project
+
+  keycloak -. Scheduled reconciliation .-> production
+  keycloak -. Scheduled reconciliation .-> stage[Stage permission instance]
+  keycloak -. Scheduled reconciliation .-> project
+
+  production -->|Private runtime API| productionRuntime[Production runtimes]
+  stage -->|Private runtime API| stageRuntime[Stage runtimes]
+  project -->|Private runtime API| projectRuntime[Project runtimes]
 ```
 
-## Global production instance
+## Production
 
-The global production `service-permissions` instance runs in the management
-cluster. It owns durable permission and identity data for its scope, reads the
-central Keycloak realm with minimum read-only access, consumes identity-change
-events, and exposes the authenticated control-plane API.
+The production permission instance owns the platform's live Minecraft policy
+and its identity projection. Portal uses its authenticated administration API,
+while production runtimes use a separate private runtime API to fetch player
+snapshots and register authorized catalog sources.
 
 <Info>
-The global production instance is a control-plane component. Minecraft plugins
-do not use it as their runtime endpoint.
+Administration and runtime traffic use separate API surfaces. Browser-facing
+routes do not expose the private runtime API.
 </Info>
 
-## Project instances
+## Stage
+
+The stage permission instance provides isolated pre-production policy and a
+private runtime API for stage workloads. This allows service and policy changes
+to be exercised without making a stage runtime depend on production runtime
+availability.
+
+<Info>
+Stage currently receives identity freshness through scheduled reconciliation.
+It does not consume the real-time project invalidation relay.
+</Info>
+
+## Projects
 
 Each project receives a `service-permissions` instance from the platform
-bundle inside that project's vCluster. The project instance keeps its own
-project-local permission data and exposes the local gRPC endpoint that the
-project's Velocity and Minestom workloads use.
+bundle. The instance keeps project-local policy and identity data. Workloads in
+that project fetch snapshots and register authorized catalog sources through
+its private REST API.
 
 Portal calls Forge's authorized project proxy. Forge forwards the request to
-the selected project instance, so Portal does not need direct network access to
-a project vCluster.
+the selected project instance after checking project access, so Portal does not
+need direct network access to the project's runtime environment.
 
 ## Identity propagation and recovery
 
 <Steps>
 <Step title="Publish an identity change">
-Keycloak publishes a minimal identity invalidation to a durable central stream.
+After a supported identity change, Keycloak publishes a minimal user-scoped
+invalidation to a durable central stream. The event contains identifiers and a
+reason, not credentials or complete permission policy.
 </Step>
 
-<Step title="Relay it to the project">
-Forge relays the invalidation to the appropriate project broker. Forge does not
-calculate runtime policy.
+<Step title="Deliver production and project invalidations">
+The stream delivers the event to the production consumer and the Forge relay.
+Forge forwards invalidations to active project brokers; it does not calculate
+runtime policy.
 </Step>
 
-<Step title="Refresh project state">
-The project service refreshes its identity projection and makes newer snapshots
-available to its local runtimes.
+<Step title="Refresh identity projections">
+The receiving permission instance refreshes its identity projection and makes
+newer snapshots available to its assigned runtimes.
 </Step>
 
 <Step title="Reconcile after delays">
-Scheduled identity reconciliation and runtime snapshot refresh recover when an
-event is delayed or unavailable.
+Scheduled identity reconciliation recovers delayed, missed, and unsupported
+events. Runtime snapshot refresh then distributes the recovered state.
 </Step>
 </Steps>
 
 ## Runtime boundary
 
-Velocity and Minestom connect only to the local `service-permissions` endpoint
-inside their own project vCluster. They fetch complete snapshots at login and
-evaluate later permission checks locally. A plugin must not call a central
-service or another project's service directly.
+Velocity and Minestom connect only to the private REST endpoint assigned to
+their environment. They fetch complete snapshots at login and evaluate later
+permission checks locally. A workload must not call another project's instance
+or cross between stage and production directly.
 
-## Security behavior
+## Security boundaries
 
-- The Keycloak reader receives only the identity read permissions it needs.
-- Forge relays authorized requests and invalidations but is not a runtime
-  policy authority.
+- Administration APIs and private runtime APIs are separate surfaces; runtime
+  routes are not exposed as public browser endpoints.
+- Managed workloads authenticate with short-lived projected tokens read from
+  files instead of static credentials in workload configuration.
+- A workload can read snapshots or register only the exact catalog sources
+  declared in its Forge manifest.
+- Forge authorizes Portal project requests before forwarding them. Project
+  owners and editors receive write access; project viewers receive read-only
+  access.
+- Keycloak invalidations contain only the identifiers and reason required to
+  refresh an identity projection.
 - Missing or expired runtime snapshots fail closed.
 - Identity state that is too stale can prevent a permission service from being
   ready until it synchronizes again.

--- a/reference/plugins/in-game-permissions/permission-catalog.mdx
+++ b/reference/plugins/in-game-permissions/permission-catalog.mdx
@@ -32,6 +32,22 @@ Place this file in your runtime artifact at
 }
 ```
 
+## Authorize the manifest source
+
+The manifest's `source` must exactly match a resource authorized by the
+workload's `catalog:register` capability. For the example above, declare:
+
+```yaml
+- capability: catalog:register
+  resources:
+    - example-lobby
+```
+
+This authorizes the workload to register `example-lobby`; it does not grant
+access to arbitrary catalog sources. See
+[Integrate In-Game Permissions](/reference/plugins/in-game-permissions/runtime-integration)
+for the complete Forge service declaration.
+
 <AccordionGroup>
 <Accordion title="Manifest requirements">
 Use one stable source ID per workload. Each manifest needs at least one entry.
@@ -48,7 +64,8 @@ list; keys must be unique within the manifest.
 | `SERVER`      | The capability applies only to one named server.          |
 
 Declare only scopes that the workload actually evaluates. Catalog metadata does
-not grant a player access by itself.
+not grant a player access by itself. Environment-scoped policy is configured by
+administrators and is not a supported workload manifest scope.
 </Accordion>
 </AccordionGroup>
 
@@ -56,8 +73,10 @@ not grant a player access by itself.
 
 The Velocity plugin discovers active plugin manifests. The Minestom module
 collects manifests from active Grounds module providers. Each runtime submits
-the collected manifest to its local project `service-permissions` instance
-after startup.
+the collected manifests asynchronously to its assigned permission instance
+after startup. Connection failures, rate limits, and service failures are
+retried with bounded backoff. Invalid manifests and other client errors require
+a corrected workload declaration or artifact and a new deployment.
 
 <Warning>
 An invalid manifest does not stop the runtime. It is skipped while the runtime

--- a/reference/plugins/in-game-permissions/runtime-integration.mdx
+++ b/reference/plugins/in-game-permissions/runtime-integration.mdx
@@ -5,32 +5,62 @@ description: "Configure the Grounds Velocity plugin or Minestom module and evalu
 
 Use the Grounds permissions modules when a Velocity proxy or Minestom
 gameserver needs to evaluate in-game permissions. Each runtime fetches a
-complete snapshot at login and evaluates later checks locally.
+complete snapshot through the private REST API at login and evaluates later
+checks locally.
 
-<Warning>
-Set `PERMISSIONS_GRPC_TARGET` to the `service-permissions` endpoint in the
-same project vCluster. Do not configure a central production endpoint or a
-service from another project.
-</Warning>
+## Declare service access
+
+Managed workloads declare their required permission-service capabilities in
+the Forge workload manifest:
+
+```yaml
+services:
+  permissions:
+    version: v1
+    access:
+      - capability: snapshot:read
+      - capability: catalog:register
+        resources:
+          - example-lobby
+```
+
+`snapshot:read` allows the workload to fetch player snapshots.
+`catalog:register` allows it to replace manifests only for the listed source
+IDs. A permissions service declaration without an access entry grants no
+permission-service access.
+
+<Tip>
+Declare only the capabilities and catalog sources your workload uses. The
+platform derives the runtime credentials and exact authorization from this
+declaration.
+</Tip>
 
 ## Configuration
 
-| Variable                               | Required | Default          | Purpose                                                                                |
-|----------------------------------------|----------|------------------|----------------------------------------------------------------------------------------|
-| `PERMISSIONS_GRPC_TARGET`              | Yes      | —                | The local project `service-permissions` gRPC endpoint. Startup fails when it is blank. |
-| `GROUNDS_PERMISSION_SERVER_TYPE`       | No       | Runtime-specific | Resolves server-type-scoped grants, for example `lobby`.                               |
-| `GROUNDS_PERMISSION_SERVER_ID`         | No       | Unset            | Resolves grants scoped to one server.                                                  |
-| `PERMISSIONS_REFRESH_INTERVAL_SECONDS` | No       | `60`             | Interval for refreshing snapshots of online players.                                   |
+| Variable                               | Required when enabled | Managed behavior                | Purpose                                                          |
+|----------------------------------------|-----------------------|---------------------------------|------------------------------------------------------------------|
+| `PERMISSIONS_SERVICE_URL`              | Yes                   | Injected                        | Base URL of the permission instance assigned to the workload.    |
+| `PERMISSIONS_TOKEN_FILE`               | Yes                   | Injected                        | Path to the projected workload token.                            |
+| `GROUNDS_PERMISSION_SERVER_TYPE`       | No                    | Runtime-specific default        | Resolves server-type-scoped grants, for example `lobby`.         |
+| `GROUNDS_PERMISSION_SERVER_ID`         | No                    | Unset                           | Resolves grants scoped to one server.                            |
+| `GROUNDS_PERMISSION_ENVIRONMENT`       | No                    | Set by the platform when needed | Resolves environment-scoped grants, such as `stage` or `prod`.   |
+| `PERMISSIONS_REFRESH_INTERVAL_SECONDS` | No                    | `60`                            | Interval for refreshing snapshots of online players.            |
 
-The platform bundle supplies the local endpoint for managed workloads. Set the
-server type and server ID only when your workload needs scoped policy.
+The integration is enabled when both `PERMISSIONS_SERVICE_URL` and
+`PERMISSIONS_TOKEN_FILE` are present. Supplying only one fails startup. Managed
+workloads receive both values from the platform; do not override them to call a
+central instance or an instance assigned to another project.
+
+The client reads the projected token file for every request, so routine token
+rotation does not require a workload restart. Never copy the token into a
+manifest, environment variable, or log message.
 
 ## Velocity
 
 Install the Velocity permissions plugin with your proxy. At proxy startup it
-registers the snapshot client, loads player snapshots during login, refreshes
-online players on the configured interval, and exposes the local `Permissions`
-service to your plugin code.
+registers the REST snapshot client, loads player snapshots during login,
+refreshes online players on the configured interval, and exposes the local
+`Permissions` service to your plugin code.
 
 Use the shared API for an unscoped check:
 
@@ -43,6 +73,7 @@ fun canModerateChat(permissions: Permissions, playerId: UUID): Boolean =
 ```
 
 Pass an explicit scope only when your code must override the runtime's default
+scope. The configured environment, server type, and server ID form that default
 scope:
 
 ```kotlin
@@ -91,9 +122,10 @@ module context.
 
 ## Snapshot lifecycle and outages
 
-1. The runtime fetches a snapshot during player login.
-2. Once `refreshAfter` passes, the periodic sweep asks the local project
-   service for a replacement while the existing snapshot remains usable.
+1. The runtime fetches a snapshot through the private runtime REST API during
+   player login.
+2. Once `refreshAfter` passes, the periodic sweep asks the assigned permission
+   instance for a replacement while the existing snapshot remains usable.
 3. A failed refresh keeps the previous snapshot until it expires.
 4. An expired snapshot makes every check return `false`.
 5. If login cannot obtain a valid snapshot, the runtime denies that login.
@@ -105,5 +137,5 @@ denial rather than retrying a remote call.
 ## Next steps
 
 - [Register your permission nodes](/reference/plugins/in-game-permissions/permission-catalog)
-- [Understand the project-local runtime topology](/reference/plugins/in-game-permissions/infrastructure)
+- [Understand the permission runtime topology](/reference/plugins/in-game-permissions/infrastructure)
 - [Manage roles and player access](/reference/plugins/in-game-permissions/administration)

--- a/superpowers/plans/2026-07-29-permissions-documentation.md
+++ b/superpowers/plans/2026-07-29-permissions-documentation.md
@@ -1,0 +1,359 @@
+# In-Game Permissions Documentation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the existing In-Game Permissions documentation so it accurately describes the current REST runtime, environment-aware policy, project synchronization, identity propagation, and security boundaries.
+
+**Architecture:** Keep the existing five-page Mintlify information architecture. Update each page according to its current responsibility, use the current `main` branches of the implementation repositories as the source of truth, and document only public architecture plus security-relevant operational behavior.
+
+**Tech Stack:** Mintlify, MDX, Mermaid, Kotlin examples, YAML workload manifests
+
+## Global Constraints
+
+- Keep the existing five-page In-Game Permissions navigation unchanged.
+- Document public architecture and security boundaries, not internal resource names or deployment parameters.
+- Use `global < environment < server type < server` as the exact scope precedence.
+- Describe the runtime as authenticated REST; remove all gRPC configuration and topology claims.
+- Never include credentials, tokens, internal hostnames, service-account names, or cluster-specific resource names.
+- Do not present planned behavior as deployed behavior.
+- Follow `AGENTS.md` and `docs/style/mintlify-writing.md`.
+
+---
+
+### Task 1: Update the permission model and administration workflow
+
+**Files:**
+- Modify: `reference/plugins/in-game-permissions/index.mdx:6-76`
+- Modify: `reference/plugins/in-game-permissions/administration.mdx:6-107`
+
+**Interfaces:**
+- Consumes: Current service scope semantics and current Portal project access and import behavior.
+- Produces: The terminology and scope precedence reused by the runtime, catalog, and infrastructure pages.
+
+- [ ] **Step 1: Update the overview topology and model**
+
+In `index.mdx`:
+
+- Change the infrastructure card copy from global/project-only wording to production, stage, and project environments.
+- Add an `Environment` row to the authorization model table.
+- Change the grant definition to include global, environment, server-type, and server scopes.
+- Explain that production owns platform policy, stage provides an isolated pre-production policy environment, and each project owns project-local policy.
+- Replace the current precedence sentence with:
+
+```mdx
+Server scope wins over server-type scope, server-type scope wins over environment
+scope, and environment scope wins over global scope. A deny wins between equally
+specific candidates.
+```
+
+- Keep the distinction between Portal access and in-game permissions.
+
+- [ ] **Step 2: Document administration access and environment grants**
+
+In `administration.mdx`:
+
+- Add an introductory `Info` callout explaining that project owners and editors can manage project permissions while project viewers have read-only access.
+- State that production permission administration uses separate platform authorization.
+- Add an `Environment` row to the role-grant table with `stage` and `prod` as examples.
+- Update effective-access guidance so administrators verify environment, server type, and server context.
+
+- [ ] **Step 3: Add the global-to-project import workflow**
+
+Add a `## Import production policy into a project` section before Audit. It must explain:
+
+1. Portal previews the current production snapshot against current project state.
+2. The user resolves each conflict by keeping the project value, using the production value, skipping the change, or removing the project value when offered.
+3. The import rejects a stale preview if project state changes before confirmation.
+4. Roles, role grants, inheritance, and catalog entries are included.
+5. Keycloak group mappings are optional and remain project-local when the checkbox is disabled.
+6. Direct player role assignments and direct player permission grants are never imported.
+
+Use a `Warning` callout for the exclusion of player-specific grants and a `Steps` component for the procedure.
+
+- [ ] **Step 4: Validate and review the model pages**
+
+Run:
+
+```bash
+mintlify validate
+git diff --check
+rg -n "global.*server-type|server-type.*global|project owners|player-specific" reference/plugins/in-game-permissions/{index,administration}.mdx
+```
+
+Expected: Mintlify validation passes, `git diff --check` prints nothing, and the search results show the new precedence, access, and import explanations.
+
+- [ ] **Step 5: Commit the model and administration update**
+
+```bash
+git add reference/plugins/in-game-permissions/index.mdx reference/plugins/in-game-permissions/administration.mdx
+git commit -m "docs: update permission administration model"
+```
+
+---
+
+### Task 2: Replace gRPC runtime documentation with authenticated REST
+
+**Files:**
+- Modify: `reference/plugins/in-game-permissions/runtime-integration.mdx:6-108`
+
+**Interfaces:**
+- Consumes: Forge service declaration schema, plugin-permissions runtime configuration, and the terminology established in Task 1.
+- Produces: The authoritative workload integration and security configuration linked from the catalog and infrastructure pages.
+
+- [ ] **Step 1: Add the Forge least-privilege declaration**
+
+Replace the gRPC warning with a prerequisites section that explains managed workloads declare their permissions access in the Forge manifest. Include this complete example:
+
+```yaml
+services:
+  permissions:
+    version: v1
+    access:
+      - capability: snapshot:read
+      - capability: catalog:register
+        resources:
+          - example-lobby
+```
+
+Explain that `snapshot:read` allows player snapshot reads, `catalog:register` allows replacement of only the listed manifest sources, and omitting access grants no permission-service access.
+
+- [ ] **Step 2: Replace the runtime configuration table**
+
+Document these exact variables:
+
+| Variable | Required | Managed behavior | Purpose |
+| --- | --- | --- | --- |
+| `PERMISSIONS_SERVICE_URL` | Yes when enabled | Injected | Base URL of the permission instance assigned to the workload. |
+| `PERMISSIONS_TOKEN_FILE` | Yes when enabled | Injected | Path to the projected workload token. |
+| `GROUNDS_PERMISSION_SERVER_TYPE` | No | Runtime-specific default | Resolves server-type-scoped grants. |
+| `GROUNDS_PERMISSION_SERVER_ID` | No | Unset | Resolves grants scoped to one server. |
+| `GROUNDS_PERMISSION_ENVIRONMENT` | No | Set by the platform where applicable | Resolves `stage` or `prod` environment grants. |
+| `PERMISSIONS_REFRESH_INTERVAL_SECONDS` | No | `60` | Refresh interval for online-player snapshots. |
+
+Add these constraints:
+
+- Managed workloads must not override the injected URL or token path to call a central or foreign project instance.
+- If only one of `PERMISSIONS_SERVICE_URL` and `PERMISSIONS_TOKEN_FILE` is set, startup fails.
+- The client rereads the token file per request so token rotation does not require a restart.
+
+- [ ] **Step 3: Retain and verify Velocity and Minestom examples**
+
+Keep the existing `Permissions.hasPermission` examples. Update surrounding text to say the snapshot is fetched through REST and evaluated locally. State that the configured environment, server type, and server ID form the default local check scope.
+
+- [ ] **Step 4: Document runtime failure behavior**
+
+Keep the existing snapshot lifecycle but clarify:
+
+- Login fetches a snapshot through the private runtime REST API.
+- Refresh failure retains a still-valid snapshot.
+- Expired or missing snapshots deny checks.
+- Login fails closed when no valid snapshot can be obtained.
+- Callers treat `false` as a local authorization decision and do not make their own remote retries.
+
+Do not publish internal endpoint hostnames or token examples.
+
+- [ ] **Step 5: Validate and scan for obsolete runtime claims**
+
+Run:
+
+```bash
+mintlify validate
+git diff --check
+rg -n "PERMISSIONS_GRPC_TARGET|gRPC endpoint|local gRPC" reference/plugins/in-game-permissions
+rg -n "PERMISSIONS_SERVICE_URL|PERMISSIONS_TOKEN_FILE|snapshot:read|catalog:register" reference/plugins/in-game-permissions/runtime-integration.mdx
+```
+
+Expected: validation passes; the obsolete-term search returns no matches; the REST and capability search finds all four required terms.
+
+- [ ] **Step 6: Commit the REST runtime update**
+
+```bash
+git add reference/plugins/in-game-permissions/runtime-integration.mdx
+git commit -m "docs: document permissions REST runtime"
+```
+
+---
+
+### Task 3: Align catalog registration with workload authorization
+
+**Files:**
+- Modify: `reference/plugins/in-game-permissions/permission-catalog.mdx:6-79`
+
+**Interfaces:**
+- Consumes: The Forge permissions declaration documented in Task 2 and plugin manifest validation rules.
+- Produces: A complete, least-privilege catalog registration workflow.
+
+- [ ] **Step 1: Link manifest sources to declared access**
+
+After the manifest example, state that its `source` must exactly match one of the `resources` under the workload's `catalog:register` capability. Link to the runtime integration page for the complete Forge declaration.
+
+Add this safe paired excerpt:
+
+```yaml
+- capability: catalog:register
+  resources:
+    - example-lobby
+```
+
+Explain that this grants registration for `example-lobby`, not arbitrary sources.
+
+- [ ] **Step 2: Complete the manifest scope and validation guidance**
+
+- Preserve the non-empty manifest, unique keys, non-empty key, label, description, and supported-scope requirements.
+- Keep the manifest scope table limited to the currently supported `GLOBAL`, `SERVER_TYPE`, and `SERVER` values. Explain environment-scoped policy on the administration page, not as a plugin manifest scope.
+- State that each entry must declare only scopes the consuming workload evaluates.
+
+- [ ] **Step 3: Clarify asynchronous registration behavior**
+
+Explain that discovered manifests register asynchronously after startup. Connection failures, rate limits, and server failures are retried with bounded backoff; invalid manifests and other client errors require a corrected workload deployment. Keep the existing statement that one invalid manifest does not prevent remaining valid manifests from registering.
+
+- [ ] **Step 4: Validate and commit the catalog update**
+
+Run:
+
+```bash
+mintlify validate
+git diff --check
+rg -n "example-lobby|catalog:register|GLOBAL|asynchronously" reference/plugins/in-game-permissions/permission-catalog.mdx
+```
+
+Expected: validation passes, whitespace validation is clean, and the source authorization, environment scope, and registration behavior are present.
+
+Then commit:
+
+```bash
+git add reference/plugins/in-game-permissions/permission-catalog.mdx
+git commit -m "docs: clarify permission catalog registration"
+```
+
+---
+
+### Task 4: Document deployment topology and security boundaries
+
+**Files:**
+- Modify: `reference/plugins/in-game-permissions/infrastructure.mdx:6-89`
+
+**Interfaces:**
+- Consumes: The environment model from Task 1 and runtime security model from Task 2.
+- Produces: The public architecture and security overview for all permission environments.
+
+- [ ] **Step 1: Replace the topology diagram**
+
+Create a Mermaid flowchart with these public components and flows:
+
+- Keycloak to durable identity stream
+- Stream to production instance
+- Stream to Forge identity relay to project broker to project instance
+- Portal to production administration API
+- Portal through Forge project proxy to project instance
+- Project instance to project runtimes
+- Stage instance to stage runtimes
+- Production instance to production runtimes
+
+Distinguish browser-facing administration paths from private runtime paths in labels. Do not name clusters, service accounts, internal hosts, or Kubernetes resources.
+
+- [ ] **Step 2: Document all three deployment shapes**
+
+Add sections for:
+
+- Production: platform policy and identity projection; its own private runtime endpoint for production workloads.
+- Stage: isolated pre-production policy and private runtime endpoint; periodic identity reconciliation currently provides freshness.
+- Projects: project-local policy and identity projection; Portal reaches it through Forge's authorized proxy; local runtimes use its private REST endpoint.
+
+State that a runtime uses the permission instance assigned to its own environment and never calls another environment directly.
+
+- [ ] **Step 3: Document event propagation and recovery**
+
+Use a `Steps` component covering:
+
+1. Keycloak publishes a minimal user-scoped invalidation after an identity change.
+2. The durable central stream delivers it to the production consumer and Forge relay.
+3. Forge relays project-relevant invalidations to project brokers.
+4. Permission instances refresh identity projections and issue newer snapshots.
+5. Periodic reconciliation recovers delayed, missed, or unsupported events.
+
+Add an `Info` callout explaining that stage currently relies on periodic reconciliation for identity freshness.
+
+- [ ] **Step 4: Document security boundaries**
+
+Add a concise list stating:
+
+- Administration APIs and private runtime APIs are separate surfaces.
+- Runtime routes are not exposed as public browser endpoints.
+- Managed workloads authenticate with short-lived projected tokens read from files.
+- Authorization is limited to declared snapshot reads and exact catalog sources.
+- Portal project requests pass through Forge authorization; project owner/editor access is writable and viewer access is read-only.
+- Keycloak events carry identifiers and invalidation reasons, not credentials or full permission policy.
+- Missing or expired snapshots fail closed.
+
+- [ ] **Step 5: Validate the full permissions section**
+
+Run:
+
+```bash
+mintlify validate
+git diff --check
+rg -n "PERMISSIONS_GRPC_TARGET|gRPC endpoint|local gRPC" reference/plugins/in-game-permissions
+rg -n "Production|Stage|project|projected token|private runtime|reconciliation" reference/plugins/in-game-permissions/infrastructure.mdx
+```
+
+Expected: Mintlify validation passes, no whitespace errors or obsolete gRPC claims remain, and all three environments plus security and recovery concepts are present.
+
+- [ ] **Step 6: Commit the infrastructure update**
+
+```bash
+git add reference/plugins/in-game-permissions/infrastructure.mdx
+git commit -m "docs: update permissions infrastructure"
+```
+
+---
+
+### Task 5: Perform final cross-page review
+
+**Files:**
+- Review: `reference/plugins/in-game-permissions/index.mdx`
+- Review: `reference/plugins/in-game-permissions/administration.mdx`
+- Review: `reference/plugins/in-game-permissions/runtime-integration.mdx`
+- Review: `reference/plugins/in-game-permissions/permission-catalog.mdx`
+- Review: `reference/plugins/in-game-permissions/infrastructure.mdx`
+
+**Interfaces:**
+- Consumes: All preceding documentation changes.
+- Produces: A validated, internally consistent documentation section ready for pull-request review.
+
+- [ ] **Step 1: Check terminology and links**
+
+Confirm every page uses `In-Game Permissions`, `production`, `stage`, `project`, `runtime`, `manifest source`, and `environment scope` consistently. Confirm all relative Mintlify links target existing pages.
+
+- [ ] **Step 2: Check examples against implementation sources**
+
+Compare the final examples with current `main`:
+
+- `grounds-forge`: permissions service declaration and capability rules
+- `plugin-permissions`: environment variables, manifest model, and Kotlin API
+- `service-permissions`: scope precedence, REST behavior, sync contents, and authentication boundaries
+- `grounds-portal`: project role access and global import behavior
+- Infrastructure repositories: production, stage, and project topology
+
+Correct any statement that differs from deployed `main` behavior.
+
+- [ ] **Step 3: Run final verification**
+
+```bash
+mintlify validate
+git diff --check
+git status -sb
+```
+
+Expected: Mintlify reports `success build validation passed`, `git diff --check` prints nothing, and the status contains only intentional plan or documentation changes.
+
+- [ ] **Step 4: Commit any final corrections**
+
+If the review changed content:
+
+```bash
+git add reference/plugins/in-game-permissions
+git commit -m "docs: refine permissions documentation"
+```
+
+If no correction was needed, do not create an empty commit.

--- a/superpowers/plans/2026-07-29-permissions-documentation.md
+++ b/superpowers/plans/2026-07-29-permissions-documentation.md
@@ -159,7 +159,7 @@ Run:
 ```bash
 mintlify validate
 git diff --check
-rg -n "PERMISSIONS_GRPC_TARGET|gRPC endpoint|local gRPC" reference/plugins/in-game-permissions
+rg -n "PERMISSIONS_GRPC_TARGET|gRPC endpoint|local gRPC" reference/plugins/in-game-permissions/runtime-integration.mdx
 rg -n "PERMISSIONS_SERVICE_URL|PERMISSIONS_TOKEN_FILE|snapshot:read|catalog:register" reference/plugins/in-game-permissions/runtime-integration.mdx
 ```
 

--- a/superpowers/specs/2026-07-29-permissions-documentation-design.md
+++ b/superpowers/specs/2026-07-29-permissions-documentation-design.md
@@ -1,0 +1,91 @@
+# In-Game Permissions documentation update
+
+## Goal
+
+Bring the existing In-Game Permissions documentation in line with the current permissions platform. The documentation should explain how administrators, plugin developers, and platform users interact with permissions without exposing internal deployment details that are not needed to use or understand the system.
+
+## Audience
+
+- Project owners, editors, and viewers who inspect or manage project permissions
+- Platform administrators who manage production permissions
+- Plugin developers who register permissions and consume runtime snapshots
+- Engineers who need a public architectural and security overview
+
+## Information architecture
+
+Keep the existing five-page section and its current navigation:
+
+1. Overview
+2. Administration
+3. Runtime integration
+4. Permission catalog
+5. Infrastructure
+
+No new top-level page or navigation entry is required.
+
+## Page changes
+
+### Overview
+
+- Explain the production, stage, and per-project permission environments.
+- Add the environment scope to the permission model.
+- Document scope precedence as `global < environment < server type < server`.
+- Retain the existing explanations of roles, inheritance, direct grants, group mappings, and deny precedence.
+
+### Administration
+
+- Explain environment-scoped grants.
+- Document project access: owners and editors can manage permissions; viewers have read-only access.
+- Document the global-to-project import workflow, including preview, per-conflict resolution, target-state protection, optional Keycloak mappings, and the exclusion of player-specific grants.
+- Distinguish project administration from platform production administration without documenting internal authorization identifiers.
+
+### Runtime integration
+
+- Replace the obsolete gRPC configuration with the authenticated REST integration.
+- Document the Forge permissions service declaration and least-privilege capabilities.
+- Explain the injected service URL and projected token file without showing real tokens.
+- Document the server type, server ID, environment, and refresh interval configuration.
+- Describe snapshot caching, refresh behavior, token rotation, and fail-closed behavior at a user-relevant level.
+- Retain Velocity and Minestom usage examples and make them consistent with the current plugin API.
+
+### Permission catalog
+
+- Retain the requirement for a non-empty manifest, unique permission keys, descriptions, and supported scopes.
+- Explain that a workload may register only manifest sources declared through `catalog:register`.
+- Show that the manifest source must match the source authorized in the Forge service declaration.
+- Describe asynchronous registration and retry behavior without documenting internal retry constants.
+
+### Infrastructure
+
+- Describe the three deployment shapes: production, stage, and per-project instances.
+- Explain the separation between browser-facing administration routes and private runtime routes.
+- Describe workload authentication through short-lived projected tokens and exact least-privilege authorization.
+- Explain the Keycloak event flow, durable central delivery, Forge relay to project brokers, and periodic reconciliation as the recovery path.
+- State the current stage behavior where periodic reconciliation provides identity freshness without presenting it as the desired permanent implementation.
+
+## Security boundaries
+
+The documentation must make these guarantees clear:
+
+- Runtime endpoints are not exposed as public browser APIs.
+- Workloads receive short-lived tokens through files rather than static credentials in configuration.
+- Each workload receives only the snapshot and catalog-source access it declares.
+- Tokens, credentials, internal service-account names, and cluster-specific resource names must not appear in examples.
+- Project access follows project roles, while production administration uses separately authorized platform access.
+
+## Deliberate exclusions
+
+Do not document:
+
+- Pulumi or Argo resource names and implementation ownership details
+- Kubernetes ClusterRole or service-account names
+- Database replica counts, backup schedules, or retention values
+- Internal hostnames, broker credentials, secrets, or token values
+- Planned behavior as if it were already deployed
+
+## Verification
+
+- Run `mintlify validate` from the documentation repository root.
+- Run `git diff --check`.
+- Review all examples against the current `main` branches of service-permissions, plugin-permissions, grounds-forge, grounds-portal, grounds-pulumi, deploy, charts, and library-platform-bundle.
+- Search the updated section for obsolete gRPC variables and claims.


### PR DESCRIPTION
# Pull Request

## Description

Updates the existing In-Game Permissions documentation to match the current permissions platform:

- documents production, stage, and project permission environments
- adds environment-scoped policy and the current scope precedence
- covers project access and production-to-project synchronization
- replaces obsolete gRPC guidance with authenticated REST runtime integration
- documents least-privilege snapshot and catalog capabilities
- explains Keycloak invalidations, the Forge project relay, reconciliation, and public security boundaries

The existing five-page information architecture remains unchanged. Internal resource names, credentials, and deployment-specific parameters are intentionally excluded.

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactoring
- [x] 📚 Documentation
- [ ] 🔧 Chore

## Related Issues

None.

## Testing

- [x] `mintlify validate`
- [x] `git diff --check`
- [x] Internal documentation links checked
- [x] Obsolete gRPC references removed from the permissions section

## Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have been added/updated and pass (if needed)
- [x] Documentation has been updated (if needed)
