### PR TITLE
docs(permissions): explain live snapshot invalidation

### DIFF
--- a/reference/plugins/in-game-permissions/infrastructure.mdx
+++ b/reference/plugins/in-game-permissions/infrastructure.mdx
@@ -9,23 +9,31 @@ runtime connects only to the permission instance assigned to that environment.
 
 ```mermaid
 flowchart TB
-  keycloak[Keycloak] --> stream[Durable identity stream]
-  stream --> production[Production permission instance]
-  stream --> forge[Forge identity relay]
-  forge --> broker[Project broker]
-  broker --> project[Project permission instance]
+  keycloak[Keycloak] --> stream[Core durable identity stream]
+  stream -->|Identity invalidation| production[Production permission instance]
+  stream -->|Identity invalidation| forge[Forge identity relay]
+  stream -->|Identity invalidation| stageBroker[Stage cluster-local broker]
+  forge -->|Identity invalidation| projectBroker[Project broker]
+  projectBroker -->|Identity invalidation| project[Project permission instance]
+  stageBroker -->|Identity invalidation| stage[Stage permission instance]
 
   portal[Portal] -->|Production administration| production
   portal -->|Project administration| proxy[Forge project proxy]
   proxy --> project
 
   keycloak -. Scheduled reconciliation .-> production
-  keycloak -. Scheduled reconciliation .-> stage[Stage permission instance]
+  keycloak -. Scheduled reconciliation .-> stage
   keycloak -. Scheduled reconciliation .-> project
 
   production -->|Private runtime API| productionRuntime[Production runtimes]
+  production -->|UUID snapshot invalidation| coreBroker[Core NATS]
+  coreBroker -->|Snapshot invalidation| productionRuntime
   stage -->|Private runtime API| stageRuntime[Stage runtimes]
+  stage -->|UUID snapshot invalidation| stageBroker
+  stageBroker -->|Snapshot invalidation| stageRuntime
   project -->|Private runtime API| projectRuntime[Project runtimes]
+  project -->|UUID snapshot invalidation| projectBroker
+  projectBroker -->|Snapshot invalidation| projectRuntime
 ```
 
 ## Production
@@ -33,7 +41,9 @@ flowchart TB
 The production permission instance owns the platform's live Minecraft policy
 and its identity projection. Portal uses its authenticated administration API,
 while production runtimes use a separate private runtime API to fetch player
-snapshots and register authorized catalog sources.
+snapshots and register authorized catalog sources. After persisting a relevant
+identity change, the instance publishes a snapshot invalidation to its assigned
+runtimes through Core NATS.
 
 <Info>
 Administration and runtime traffic use separate API surfaces. Browser-facing
@@ -48,8 +58,9 @@ to be exercised without making a stage runtime depend on production runtime
 availability.
 
 <Info>
-Stage currently receives identity freshness through scheduled reconciliation.
-It does not consume the real-time project invalidation relay.
+Stage consumes real-time identity changes and publishes snapshot invalidations
+through its private cluster-local NATS broker. Scheduled reconciliation and the
+runtime snapshot sweep remain fallback paths for missed or delayed events.
 </Info>
 
 ## Projects
@@ -57,7 +68,9 @@ It does not consume the real-time project invalidation relay.
 Each project receives a `service-permissions` instance from the platform
 bundle. The instance keeps project-local policy and identity data. Workloads in
 that project fetch snapshots and register authorized catalog sources through
-its private REST API.
+its private REST API. The bundle declares the instance's publish subject and
+each runtime's subscribe subject, and it supplies each runtime's `NATS_URL`
+from the shared project broker explicitly.
 
 Portal calls Forge's authorized project proxy. Forge forwards the request to
 the selected project instance after checking project access, so Portal does not
@@ -79,13 +92,21 @@ runtime policy.
 </Step>
 
 <Step title="Refresh identity projections">
-The receiving permission instance refreshes its identity projection and makes
-newer snapshots available to its assigned runtimes.
+The receiving permission instance refreshes and persists its identity
+projection. It then publishes one snapshot invalidation for each changed
+Minecraft UUID.
+</Step>
+
+<Step title="Refresh online runtime snapshots">
+Each assigned runtime receives the invalidation for an online player and
+force-fetches the authoritative snapshot through private REST. It atomically
+replaces the local snapshot only after a successful response.
 </Step>
 
 <Step title="Reconcile after delays">
 Scheduled identity reconciliation recovers delayed, missed, and unsupported
-events. Runtime snapshot refresh then distributes the recovered state.
+events. The periodic runtime sweep retries snapshots after `refreshAfter`, and
+snapshot expiry keeps authorization fail closed.
 </Step>
 </Steps>
 
@@ -93,8 +114,19 @@ events. Runtime snapshot refresh then distributes the recovered state.
 
 Velocity and Minestom connect only to the private REST endpoint assigned to
 their environment. They fetch complete snapshots at login and evaluate later
-permission checks locally. A workload must not call another project's instance
-or cross between stage and production directly.
+permission checks locally. NATS carries only a refresh signal; private REST
+remains the authoritative data path. A workload must not call another project's
+instance or cross between stage and production directly.
+
+The runtime invalidation payload contains exactly a schema version and
+Minecraft UUID:
+
+```json
+{"schemaVersion":1,"playerId":"0f287625-2442-4f55-b928-d2f53fbdf575"}
+```
+
+It contains no username, Keycloak identifier, group, role, grant, permission,
+token, or project identifier.
 
 ## Security boundaries
 
@@ -104,11 +136,24 @@ or cross between stage and production directly.
   files instead of static credentials in workload configuration.
 - A workload can read snapshots or register only the exact catalog sources
   declared in its Forge manifest.
+- Project NATS publish and subscribe subjects come from each component's
+  `events:` declaration and are enforced through its projected workload
+  identity. The bundle supplies `NATS_URL` separately; an event declaration
+  alone does not configure transport.
+- Receiving a snapshot invalidation never grants REST access. Every replacement
+  fetch still requires the independent `snapshot:read` capability.
+- The global production permission instance publishes through its dedicated
+  NATS identity credential. Keycloak and Forge relay identities do not receive
+  permission to publish the snapshot invalidation subject.
+- Stage keeps NATS traffic inside its private cluster-local broker boundary.
+  Broader Stage client-auth hardening remains separate platform work.
 - Forge authorizes Portal project requests before forwarding them. Project
   owners and editors receive write access; project viewers receive read-only
   access.
 - Keycloak invalidations contain only the identifiers and reason required to
   refresh an identity projection.
+- Runtime snapshot invalidations contain only the schema version and Minecraft
+  UUID. A failed replacement fetch keeps the previous valid snapshot.
 - Missing or expired runtime snapshots fail closed.
 - Identity state that is too stale can prevent a permission service from being
   ready until it synchronizes again.

--- a/reference/plugins/in-game-permissions/runtime-integration.mdx
+++ b/reference/plugins/in-game-permissions/runtime-integration.mdx
@@ -8,41 +8,89 @@ gameserver needs to evaluate in-game permissions. Each runtime fetches a
 complete snapshot through the private REST API at login and evaluates later
 checks locally.
 
-## Declare service access
+## Declare service and event access
 
-Managed workloads declare their required permission-service capabilities in
-the Forge workload manifest:
+Managed applications declare permission-service access, NATS subject access,
+and transport on their component in the platform bundle. Use the environment
+field supported by the component's chart:
 
+<Tabs>
+<Tab title="Velocity">
 ```yaml
-services:
-  permissions:
-    version: v1
-    access:
-      - capability: snapshot:read
-      - capability: catalog:register
-        resources:
-          - example-lobby
-events:
-  - subject: permissions.snapshot.invalidated
-    dir: sub
-helm:
-  extraEnv:
-    - name: NATS_URL
-      valueFrom: shared.nats
+components:
+  velocity:
+    type: plugin-velocity-base
+    chart:
+      url: oci://ghcr.io/groundsgg/charts/grounds-velocity
+      version: 0.8.0
+    image: ghcr.io/groundsgg/velocity
+    version: 0.13.0
+    services:
+      permissions:
+        version: v1
+        access:
+          - capability: snapshot:read
+          - capability: catalog:register
+            resources:
+              - plugin-permissions
+              - plugin-agones
+              - plugin-chat
+    helm:
+      env:
+        - name: NATS_URL
+          valueFrom: shared.nats
+    events:
+      - subject: permissions.snapshot.invalidated
+        dir: sub
 ```
+</Tab>
+
+<Tab title="Minestom (grounds-gamemode)">
+```yaml
+components:
+  minestom-lobby:
+    type: gamemode
+    chart:
+      url: oci://ghcr.io/groundsgg/charts/grounds-gamemode
+      version: 0.8.0
+    image: ghcr.io/groundsgg/minestom-lobby
+    version: 1.4.0
+    services:
+      permissions:
+        version: v1
+        access:
+          - capability: snapshot:read
+    helm:
+      kind: lobby
+      extraEnv:
+        - name: NATS_URL
+          valueFrom: shared.nats
+    events:
+      - subject: permissions.snapshot.invalidated
+        dir: sub
+```
+</Tab>
+</Tabs>
 
 `snapshot:read` allows the workload to fetch player snapshots.
 `catalog:register` allows it to replace manifests only for the listed source
-IDs. The `events` entry allows the projected workload identity to subscribe to
-snapshot invalidations. It does not configure the broker endpoint, so the
-bundle must also provide `NATS_URL` explicitly from the shared NATS transport.
+IDs. These are application-level bundle declarations, not the environment
+variables or volumes rendered into the pod.
+
+The platform projection turns `services.permissions.access` into the private
+REST endpoint, token-file path, and exact REST authorization. It turns
+`events:` into NATS subject authorization enforced by a projected workload
+identity. The chart-specific `helm.env` or `helm.extraEnv` entry separately
+passes the shared broker endpoint as `NATS_URL`. Declaring an event never
+configures `NATS_URL` by itself.
+
 A permissions service declaration without an access entry grants no
 permission-service access, even when the event subscription is present.
 
 <Tip>
 Declare only the capabilities and catalog sources your workload uses. The
-platform derives the runtime credentials and exact authorization from this
-declaration.
+platform derives runtime credentials and exact authorization from the service
+and event declarations, while the chart environment selects the transport.
 </Tip>
 
 ## Configuration
@@ -66,10 +114,9 @@ central instance or an instance assigned to another project.
 
 The client reads the projected token file for every request, so routine token
 rotation does not require a workload restart. Never copy the token into a
-manifest, environment variable, or log message. Managed workloads receive the
-event subject, broker endpoint, and token-file path from their bundle
-declaration and platform projection; put only token-file paths in
-configuration, never token values.
+manifest, environment variable, or log message. The bundle declares access and
+the broker endpoint; the platform projection injects the resulting token-file
+paths. Put only token-file paths in configuration, never token values.
 
 ## Velocity
 

--- a/reference/plugins/in-game-permissions/runtime-integration.mdx
+++ b/reference/plugins/in-game-permissions/runtime-integration.mdx
@@ -22,12 +22,22 @@ services:
       - capability: catalog:register
         resources:
           - example-lobby
+events:
+  - subject: permissions.snapshot.invalidated
+    dir: sub
+helm:
+  extraEnv:
+    - name: NATS_URL
+      valueFrom: shared.nats
 ```
 
 `snapshot:read` allows the workload to fetch player snapshots.
 `catalog:register` allows it to replace manifests only for the listed source
-IDs. A permissions service declaration without an access entry grants no
-permission-service access.
+IDs. The `events` entry allows the projected workload identity to subscribe to
+snapshot invalidations. It does not configure the broker endpoint, so the
+bundle must also provide `NATS_URL` explicitly from the shared NATS transport.
+A permissions service declaration without an access entry grants no
+permission-service access, even when the event subscription is present.
 
 <Tip>
 Declare only the capabilities and catalog sources your workload uses. The
@@ -37,14 +47,17 @@ declaration.
 
 ## Configuration
 
-| Variable                               | Required when enabled | Managed behavior                | Purpose                                                          |
-|----------------------------------------|-----------------------|---------------------------------|------------------------------------------------------------------|
-| `PERMISSIONS_SERVICE_URL`              | Yes                   | Injected                        | Base URL of the permission instance assigned to the workload.    |
-| `PERMISSIONS_TOKEN_FILE`               | Yes                   | Injected                        | Path to the projected workload token.                            |
-| `GROUNDS_PERMISSION_SERVER_TYPE`       | No                    | Runtime-specific default        | Resolves server-type-scoped grants, for example `lobby`.         |
-| `GROUNDS_PERMISSION_SERVER_ID`         | No                    | Unset                           | Resolves grants scoped to one server.                            |
-| `GROUNDS_PERMISSION_ENVIRONMENT`       | No                    | Set by the platform when needed | Resolves environment-scoped grants, such as `stage` or `prod`.   |
-| `PERMISSIONS_REFRESH_INTERVAL_SECONDS` | No                    | `60`                            | Interval for refreshing snapshots of online players.            |
+| Variable                                     | Required when enabled | Managed behavior                 | Purpose                                                               |
+|----------------------------------------------|-----------------------|----------------------------------|-----------------------------------------------------------------------|
+| `PERMISSIONS_SERVICE_URL`                    | Yes                   | Injected                         | Base URL of the permission instance assigned to the workload.         |
+| `PERMISSIONS_TOKEN_FILE`                     | Yes                   | Injected                         | Path to the projected token used for private REST requests.           |
+| `NATS_URL`                                   | For live invalidation | Declared explicitly by the bundle | Broker endpoint used to receive snapshot invalidations.               |
+| `GROUNDS_TOKEN_FILE`                         | When NATS requires it | Injected for managed workloads   | Path to the projected token used for the authorized NATS subscription. |
+| `PERMISSIONS_SNAPSHOT_INVALIDATIONS_SUBJECT` | No                    | Default subject                  | Overrides `permissions.snapshot.invalidated`.                         |
+| `GROUNDS_PERMISSION_SERVER_TYPE`             | No                    | Runtime-specific default         | Resolves server-type-scoped grants, for example `lobby`.              |
+| `GROUNDS_PERMISSION_SERVER_ID`               | No                    | Unset                            | Resolves grants scoped to one server.                                 |
+| `GROUNDS_PERMISSION_ENVIRONMENT`             | No                    | Set by the platform when needed  | Resolves environment-scoped grants, such as `stage` or `prod`.        |
+| `PERMISSIONS_REFRESH_INTERVAL_SECONDS`       | No                    | `60`                             | Interval for refreshing snapshots of online players.                 |
 
 The integration is enabled when both `PERMISSIONS_SERVICE_URL` and
 `PERMISSIONS_TOKEN_FILE` are present. Supplying only one fails startup. Managed
@@ -53,7 +66,10 @@ central instance or an instance assigned to another project.
 
 The client reads the projected token file for every request, so routine token
 rotation does not require a workload restart. Never copy the token into a
-manifest, environment variable, or log message.
+manifest, environment variable, or log message. Managed workloads receive the
+event subject, broker endpoint, and token-file path from their bundle
+declaration and platform projection; put only token-file paths in
+configuration, never token values.
 
 ## Velocity
 
@@ -124,11 +140,27 @@ module context.
 
 1. The runtime fetches a snapshot through the private runtime REST API during
    player login.
-2. Once `refreshAfter` passes, the periodic sweep asks the assigned permission
-   instance for a replacement while the existing snapshot remains usable.
-3. A failed refresh keeps the previous snapshot until it expires.
-4. An expired snapshot makes every check return `false`.
-5. If login cannot obtain a valid snapshot, the runtime denies that login.
+2. For an online player, the runtime receives a NATS invalidation containing
+   only the schema version and Minecraft UUID.
+3. The runtime force-fetches the authoritative snapshot through private REST
+   and atomically replaces its local snapshot after a successful response.
+4. A failed invalidation refresh keeps the previous snapshot. Once
+   `refreshAfter` passes, the periodic sweep retries the assigned permission
+   instance while that snapshot remains usable.
+5. Snapshot expiry remains the fail-closed boundary: an expired snapshot makes
+   every check return `false`.
+6. If login cannot obtain a valid snapshot, the runtime denies that login.
+
+The invalidation carries no roles, grants, permissions, username, or project
+identifier. It is a prompt to re-read state, not an authorization result.
+Receiving it does not replace the independently authorized `snapshot:read`
+REST request. Events for offline players do not trigger a fetch because their
+next login loads the current snapshot.
+
+If NATS is unavailable during startup or reconnect, the runtime continues to
+serve from valid local snapshots. Login loading, the periodic `refreshAfter`
+sweep, and expiry provide recovery without making event transport part of the
+authorization decision.
 
 This fail-closed behavior prevents a temporary service outage from granting
 unverified permissions. Handle a `false` result as an ordinary authorization


### PR DESCRIPTION
## Summary

- document the released live permission snapshot invalidation lifecycle
- explain the UUID-only event payload, REST authorization boundary, atomic replacement, and periodic recovery
- describe project, global production, and Stage NATS security boundaries
- provide chart-specific Velocity and Minestom bundle examples for the explicit NATS transport

## Verification

- `mint validate`
- frontmatter and internal-link checks
- `git diff --check origin/main...HEAD`
